### PR TITLE
Implement modifications on limiters for convergence test 

### DIFF
--- a/src/CLUBB_core/adg1_adg2_3d_luhar_pdf.F90
+++ b/src/CLUBB_core/adg1_adg2_3d_luhar_pdf.F90
@@ -147,35 +147,19 @@ module adg1_adg2_3d_luhar_pdf
 
     integer :: j  ! Loop index
 
-!$acc data copyin(wm(:ngrdcol,:nz), wp2(:ngrdcol,:nz), &
-!$acc um(:ngrdcol,:nz) , vm(:ngrdcol,:nz),             &
-!$acc sigma_sqd_w(:ngrdcol,:nz), Skw(:ngrdcol,:nz),    &
-!$acc sqrt_wp2(:ngrdcol,:nz), beta, mixt_frac_max_mag,   &
-!$acc rtm(:ngrdcol,:nz), thlm(:ngrdcol,:nz),      &
-!$acc rtp2(:ngrdcol,:nz), thlp2(:ngrdcol,:nz),    &
-!$acc wprtp(:ngrdcol,:nz), wpthlp(:ngrdcol,:nz),  &
-!$acc sclrm(ngrdcol,nz, sclr_dim), sclrp2(ngrdcol,nz, sclr_dim), &
-!$acc wpsclrp(ngrdcol,nz, sclr_dim), l_scalar_calc,         &
-!$acc w_1_n(ngrdcol,nz), w_2_n(ngrdcol,nz),         &
-!$acc up2(ngrdcol,nz), vp2(ngrdcol,nz),       &
-!$acc upwp(ngrdcol,nz), vpwp(ngrdcol,nz)  &
-!$acc ) copyout(mixt_frac(:ngrdcol,:nz), w_1(:ngrdcol,:nz),   &
-!$acc w_2(:ngrdcol,:nz), alpha_thl(:ngrdcol,:nz),      &
-!$acc varnce_w_2(:ngrdcol,:nz), varnce_w_1(:ngrdcol,:nz),  &
-!$acc rt_1(:ngrdcol,:nz), rt_2(:ngrdcol,:nz),         &
-!$acc u_1(:ngrdcol,:nz), u_2(:ngrdcol,:nz),         &
-!$acc v_1(:ngrdcol,:nz), v_2(:ngrdcol,:nz),         &
-!$acc thl_1(:ngrdcol,:nz), thl_2(:ngrdcol,:nz),        &
-!$acc varnce_rt_1(:ngrdcol,:nz), varnce_rt_2(:ngrdcol,:nz),  &
-!$acc varnce_thl_1(:ngrdcol,:nz), varnce_thl_2(:ngrdcol,:nz), &
-!$acc varnce_u_1(:ngrdcol,:nz), varnce_u_2(:ngrdcol,:nz), &
-!$acc varnce_v_1(:ngrdcol,:nz), varnce_v_2(:ngrdcol,:nz), &
-!$acc alpha_rt(:ngrdcol,:nz), sigma_sqd_w(:ngrdcol,:nz),  &
-!$acc alpha_u(:ngrdcol,:nz), alpha_v(:ngrdcol,:nz),  &
-!$acc sclr_1(ngrdcol,nz, sclr_dim), sclr_2(ngrdcol,nz, sclr_dim),        &
-!$acc varnce_sclr_1(ngrdcol,nz, sclr_dim), varnce_sclr_2(ngrdcol,nz, sclr_dim), &
-!$acc alpha_sclr(ngrdcol,nz, sclr_dim)       &
-!$acc )
+    !$acc data create( w_1_n, w_2_n ) &
+    !$acc      copyin( wm, wp2, um , vm, &
+    !$acc              sigma_sqd_w, Skw, sqrt_wp2, &
+    !$acc              rtm, thlm, rtp2, thlp2, &
+    !$acc              wprtp, wpthlp, sclrm, sclrp2, &
+    !$acc              wpsclrp, up2, vp2, upwp, vpwp )  &
+    !$acc     copyout( mixt_frac, w_1, w_2, alpha_thl, &
+    !$acc              varnce_w_2, varnce_w_1, rt_1, rt_2, u_1, u_2, &
+    !$acc              v_1, v_2, thl_1, thl_2, varnce_rt_1, varnce_rt_2,  &
+    !$acc              varnce_thl_1, varnce_thl_2, varnce_u_1, varnce_u_2, &
+    !$acc              varnce_v_1, varnce_v_2, alpha_rt, sigma_sqd_w,  &
+    !$acc              alpha_u, alpha_v, sclr_1, sclr_2, &
+    !$acc              varnce_sclr_1, varnce_sclr_2, alpha_sclr )
     
     ! Calculate the mixture fraction and the PDF component means and variances
     ! of w.
@@ -231,7 +215,9 @@ module adg1_adg2_3d_luhar_pdf
                                            alpha_sclr(:,:,j) )              ! Out
        enddo ! i=1, sclr_dim
     endif ! l_scalar_calc
-!$acc end data
+
+    !$acc end data
+    
     return
 
   end subroutine ADG1_pdf_driver

--- a/src/CLUBB_core/advance_clubb_core_module.F90
+++ b/src/CLUBB_core/advance_clubb_core_module.F90
@@ -1348,6 +1348,7 @@ module advance_clubb_core_module
                         clubb_config_flags%l_brunt_vaisala_freq_moist,            & ! In
                         clubb_config_flags%l_use_thvm_in_bv_freq,                 & ! In
                         clubb_config_flags%l_smooth_Heaviside_tau_wpxp,           & ! In
+                        clubb_config_flags%l_use_modify_limiters,                 & ! In
                         brunt_vaisala_freq_sqd, brunt_vaisala_freq_sqd_mixed,     & ! Out
                         brunt_vaisala_freq_sqd_dry, brunt_vaisala_freq_sqd_moist, & ! Out
                         brunt_vaisala_freq_sqd_plus,                              & ! Out
@@ -1671,6 +1672,7 @@ module advance_clubb_core_module
                                       clubb_config_flags%l_brunt_vaisala_freq_moist, & ! intent(in)
                                       clubb_config_flags%l_use_thvm_in_bv_freq,      & ! intent(in
                                       clubb_config_flags%l_use_shear_Richardson,     & ! intent(in)
+                                      clubb_config_flags%l_use_modify_limiters,      & ! intent(in)
                                       stats_zm,                                      & ! intent(inout)
                                       Cx_fnc_Richardson )                              ! intent(out)
     else

--- a/src/CLUBB_core/advance_helper_module.F90
+++ b/src/CLUBB_core/advance_helper_module.F90
@@ -501,6 +501,7 @@ module advance_helper_module
                                         l_brunt_vaisala_freq_moist, &
                                         l_use_thvm_in_bv_freq, &
                                         l_use_shear_Richardson, &
+                                        l_use_modify_limiters, & 
                                         stats_zm, & 
                                         Cx_fnc_Richardson )
 
@@ -517,7 +518,8 @@ module advance_helper_module
     use grid_class, only: &
         grid, & ! Type
         ddzt, & ! Procedure(s)
-        zt2zm
+        zt2zm, & 
+        zm2zt
 
     use constants_clubb, only: &
         one, zero
@@ -588,7 +590,9 @@ module advance_helper_module
       l_brunt_vaisala_freq_moist, & ! Use a different formula for the Brunt-Vaisala frequency in
                                     ! saturated atmospheres (from Durran and Klemp, 1982)
       l_use_thvm_in_bv_freq,      & ! Use thvm in the calculation of Brunt-Vaisala frequency
-      l_use_shear_Richardson        ! Use shear in the calculation of Richardson number
+      l_use_shear_Richardson,     & ! Use shear in the calculation of Richardson number
+      l_use_modify_limiters         ! Flag to activate modifications on limiters to improve 
+                                    ! the solution convergence 
 
     ! Output Variable
     real( kind = core_rknd), dimension(ngrdcol,nz), intent(out) :: &
@@ -617,6 +621,12 @@ module advance_helper_module
       Richardson_num_min    ! CLUBB tunable parameter Richardson_num_min
       
     integer :: i
+
+    real( kind = core_rknd ), parameter :: &
+      min_max_smth_mag = 1.0e-9_core_rknd ! "base" smoothing magnitude before scaling 
+                                          ! for the respective data structure. See
+                                          ! https://github.com/larson-group/clubb/issues/965#issuecomment-1119816722
+                                          ! for a plot on how output behaves with varying min_max_smth_mag
 
   !-----------------------------------------------------------------------
 
@@ -683,10 +693,25 @@ module advance_helper_module
     ! Cx_fnc_Richardson is interpolated based on the value of Richardson_num
     ! The min function ensures that Cx does not exceed Cx_max, regardless of the
     !     value of Richardson_num_max.
-    Cx_fnc_Richardson = linear_interp_factor( &
-                    ( max(min(Richardson_num_max,Ri_zm),Richardson_num_min) &
-                    - Richardson_num_min )  * invrs_min_max_diff, &
-                                              clubb_params(iCx_max), clubb_params(iCx_min) )
+    if (l_use_modify_limiters) then 
+
+      Cx_fnc_Richardson = linear_interp_factor( &
+                     smooth_max(nz, ngrdcol, zero, & 
+                                smooth_min(nz, ngrdcol, one,&  
+                                           (Ri_zm-Richardson_num_min)*invrs_min_max_diff, &
+                                               one * min_max_smth_mag), &
+                     one * min_max_smth_mag), clubb_params(iCx_max), clubb_params(iCx_min) )
+
+      Cx_fnc_Richardson = zt2zm(nz, ngrdcol, gr, zm2zt(nz, ngrdcol, gr,Cx_fnc_Richardson))
+
+    else ! default setup 
+
+      Cx_fnc_Richardson = linear_interp_factor( &
+                      ( max(min(Richardson_num_max,Ri_zm),Richardson_num_min) &
+                      - Richardson_num_min )  * invrs_min_max_diff, &
+                                               clubb_params(iCx_max), clubb_params(iCx_min) )
+
+    end if 
 
     if ( l_Cx_fnc_Richardson_vert_avg ) then
       Cx_fnc_Richardson = Lscale_width_vert_avg( nz, ngrdcol, gr, &

--- a/src/CLUBB_core/clubb_api_module.F90
+++ b/src/CLUBB_core/clubb_api_module.F90
@@ -4535,7 +4535,8 @@ contains
                                                  l_mono_flux_lim_um, & ! Out
                                                  l_mono_flux_lim_vm, & ! Out
                                                  l_mono_flux_lim_spikefix, & !Out 
-                                                 l_modify_ic_for_cnvg_test ) ! Out
+                                                 l_modify_ic_for_cnvg_test, & !Out
+                                                 l_modify_bc_for_cnvg_test ) ! Out
 
     use model_flags, only: &
         set_default_clubb_config_flags  ! Procedure
@@ -4669,8 +4670,10 @@ contains
                                       ! eliminates spurious drying tendencies at model top
 
     logical, intent(out) :: &
-      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                                ! for convergence test 
+      l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                   ! for convergence test 
+      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                   ! for convergence test 
 
     call set_default_clubb_config_flags( iiPDF_type, & ! Out
                                          ipdf_call_placement, & ! Out
@@ -4728,7 +4731,8 @@ contains
                                          l_mono_flux_lim_um, & ! Out
                                          l_mono_flux_lim_vm, & ! Out
                                          l_mono_flux_lim_spikefix, & ! Out 
-                                         l_modify_ic_for_cnvg_test ) ! Out
+                                         l_modify_ic_for_cnvg_test, & ! Out
+                                         l_modify_bc_for_cnvg_test ) ! Out
 
   end subroutine set_default_clubb_config_flags_api
 
@@ -4792,6 +4796,7 @@ contains
                                                      l_mono_flux_lim_vm, & ! In
                                                      l_mono_flux_lim_spikefix, & ! In
                                                      l_modify_ic_for_cnvg_test,& ! In
+                                                     l_modify_bc_for_cnvg_test,& ! In
                                                      clubb_config_flags ) ! Out
 
     use model_flags, only: &
@@ -4926,8 +4931,10 @@ contains
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
     logical, intent(in) :: &
-      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                                ! for convergence test 
+      l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                   ! for convergence test 
+      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                   ! for convergence test 
 
     ! Output variables
     type(clubb_config_flags_type), intent(out) :: &
@@ -4990,6 +4997,7 @@ contains
                                              l_mono_flux_lim_vm, & ! In
                                              l_mono_flux_lim_spikefix, & ! In
                                              l_modify_ic_for_cnvg_test, & ! In
+                                             l_modify_bc_for_cnvg_test, & ! In 
                                              clubb_config_flags ) ! Out
 
   end subroutine initialize_clubb_config_flags_type_api

--- a/src/CLUBB_core/clubb_api_module.F90
+++ b/src/CLUBB_core/clubb_api_module.F90
@@ -4549,6 +4549,7 @@ contains
                                                  l_mono_flux_lim_spikefix, & !Out 
                                                  l_modify_ic_for_cnvg_test, & !Out
                                                  l_modify_bc_for_cnvg_test, & !Out 
+                                                 l_use_modify_limiters, & !Out 
                                                  l_linear_diffusion ) ! Out
 
     use model_flags, only: &
@@ -4687,6 +4688,8 @@ contains
                                    ! for convergence test 
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations
 
@@ -4748,6 +4751,7 @@ contains
                                          l_mono_flux_lim_spikefix, & ! Out 
                                          l_modify_ic_for_cnvg_test, & ! Out
                                          l_modify_bc_for_cnvg_test, & ! Out 
+                                         l_use_modify_limiters, & ! Out 
                                          l_linear_diffusion ) ! Out
 
   end subroutine set_default_clubb_config_flags_api
@@ -4813,6 +4817,7 @@ contains
                                                      l_mono_flux_lim_spikefix, & ! In
                                                      l_modify_ic_for_cnvg_test, & ! In
                                                      l_modify_bc_for_cnvg_test, & ! In
+                                                     l_use_modify_limiters, & ! In 
                                                      l_linear_diffusion, & ! In 
                                                      clubb_config_flags ) ! Out
 
@@ -4952,6 +4957,8 @@ contains
                                    ! for convergence test 
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations
 
@@ -5017,6 +5024,7 @@ contains
                                              l_mono_flux_lim_spikefix, & ! In
                                              l_modify_ic_for_cnvg_test, & ! In
                                              l_modify_bc_for_cnvg_test, & ! In 
+                                             l_use_modify_limiters, & ! In 
                                              l_linear_diffusion, & ! In 
                                              clubb_config_flags ) ! Out
 

--- a/src/CLUBB_core/clubb_api_module.F90
+++ b/src/CLUBB_core/clubb_api_module.F90
@@ -4534,7 +4534,8 @@ contains
                                                  l_mono_flux_lim_rtm, & ! Out
                                                  l_mono_flux_lim_um, & ! Out
                                                  l_mono_flux_lim_vm, & ! Out
-                                                 l_mono_flux_lim_spikefix ) ! Out
+                                                 l_mono_flux_lim_spikefix, & !Out 
+                                                 l_modify_ic_for_cnvg_test ) ! Out
 
     use model_flags, only: &
         set_default_clubb_config_flags  ! Procedure
@@ -4667,6 +4668,10 @@ contains
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
 
+    logical, intent(out) :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
+
     call set_default_clubb_config_flags( iiPDF_type, & ! Out
                                          ipdf_call_placement, & ! Out
                                          penta_solve_method, & ! Out
@@ -4722,7 +4727,8 @@ contains
                                          l_mono_flux_lim_rtm, & ! Out
                                          l_mono_flux_lim_um, & ! Out
                                          l_mono_flux_lim_vm, & ! Out
-                                         l_mono_flux_lim_spikefix ) ! Out
+                                         l_mono_flux_lim_spikefix, & ! Out 
+                                         l_modify_ic_for_cnvg_test ) ! Out
 
   end subroutine set_default_clubb_config_flags_api
 
@@ -4785,6 +4791,7 @@ contains
                                                      l_mono_flux_lim_um, & ! In
                                                      l_mono_flux_lim_vm, & ! In
                                                      l_mono_flux_lim_spikefix, & ! In
+                                                     l_modify_ic_for_cnvg_test,& ! In
                                                      clubb_config_flags ) ! Out
 
     use model_flags, only: &
@@ -4918,6 +4925,9 @@ contains
       l_mono_flux_lim_vm,           & ! Flag to turn on monotonic flux limiter for vm
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
+    logical, intent(in) :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
 
     ! Output variables
     type(clubb_config_flags_type), intent(out) :: &
@@ -4979,6 +4989,7 @@ contains
                                              l_mono_flux_lim_um, & ! In
                                              l_mono_flux_lim_vm, & ! In
                                              l_mono_flux_lim_spikefix, & ! In
+                                             l_modify_ic_for_cnvg_test, & ! In
                                              clubb_config_flags ) ! Out
 
   end subroutine initialize_clubb_config_flags_type_api

--- a/src/CLUBB_core/clubb_api_module.F90
+++ b/src/CLUBB_core/clubb_api_module.F90
@@ -2607,6 +2607,7 @@ contains
              deltaz, params, nzmax, &
              grid_type, momentum_heights, thermodynamic_heights, &
              l_prescribed_avg_deltaz, &
+             l_linear_diffusion, & 
              lmin, nu_vert_res_dep, err_code_api )
 
     use parameters_tunable, only: &
@@ -2654,6 +2655,10 @@ contains
     logical, intent(in) :: &
       l_prescribed_avg_deltaz ! used in adj_low_res_nu. If .true., avg_deltaz = deltaz
 
+    logical, intent(in) :: & 
+      l_linear_diffusion      ! Flag to use linear diffusion instead of nonlinear diffusion 
+                              ! as numerical smoothing in clubb equations
+
     ! Output Variables 
     real( kind = core_rknd ), intent(out) :: &
       lmin    ! Min. value for the length scale    [m]
@@ -2680,6 +2685,7 @@ contains
               deltaz_col, params, nzmax, 1, &
               grid_type, momentum_heights, thermodynamic_heights, &
               l_prescribed_avg_deltaz, &
+              l_linear_diffusion, &  
               lmin, nu_vert_res_dep, err_code_api )
 
   end subroutine setup_parameters_api_single_col
@@ -2692,6 +2698,7 @@ contains
              deltaz, params, nzmax, ngrdcol, &
              grid_type, momentum_heights, thermodynamic_heights, &
              l_prescribed_avg_deltaz, &
+             l_linear_diffusion, & 
              lmin, nu_vert_res_dep, err_code_api )
 
     use parameters_tunable, only: &
@@ -2741,6 +2748,10 @@ contains
     logical, intent(in) :: &
       l_prescribed_avg_deltaz ! used in adj_low_res_nu. If .true., avg_deltaz = deltaz
 
+    logical, intent(in) :: &
+      l_linear_diffusion      ! Flag to use linear diffusion instead of nonlinear diffusion 
+                              ! as numerical smoothing in clubb equations
+
     ! Output Variables 
     real( kind = core_rknd ), intent(out) :: &
       lmin    ! Min. value for the length scale    [m]
@@ -2755,6 +2766,7 @@ contains
               deltaz, params, nzmax, ngrdcol, &
               grid_type, momentum_heights, thermodynamic_heights, &
               l_prescribed_avg_deltaz, &
+              l_linear_diffusion, & 
               lmin, nu_vert_res_dep, err_code_api )
 
   end subroutine setup_parameters_api_multi_col
@@ -4536,7 +4548,8 @@ contains
                                                  l_mono_flux_lim_vm, & ! Out
                                                  l_mono_flux_lim_spikefix, & !Out 
                                                  l_modify_ic_for_cnvg_test, & !Out
-                                                 l_modify_bc_for_cnvg_test ) ! Out
+                                                 l_modify_bc_for_cnvg_test, & !Out 
+                                                 l_linear_diffusion ) ! Out
 
     use model_flags, only: &
         set_default_clubb_config_flags  ! Procedure
@@ -4672,8 +4685,10 @@ contains
     logical, intent(out) :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test 
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations
 
     call set_default_clubb_config_flags( iiPDF_type, & ! Out
                                          ipdf_call_placement, & ! Out
@@ -4732,7 +4747,8 @@ contains
                                          l_mono_flux_lim_vm, & ! Out
                                          l_mono_flux_lim_spikefix, & ! Out 
                                          l_modify_ic_for_cnvg_test, & ! Out
-                                         l_modify_bc_for_cnvg_test ) ! Out
+                                         l_modify_bc_for_cnvg_test, & ! Out 
+                                         l_linear_diffusion ) ! Out
 
   end subroutine set_default_clubb_config_flags_api
 
@@ -4795,8 +4811,9 @@ contains
                                                      l_mono_flux_lim_um, & ! In
                                                      l_mono_flux_lim_vm, & ! In
                                                      l_mono_flux_lim_spikefix, & ! In
-                                                     l_modify_ic_for_cnvg_test,& ! In
-                                                     l_modify_bc_for_cnvg_test,& ! In
+                                                     l_modify_ic_for_cnvg_test, & ! In
+                                                     l_modify_bc_for_cnvg_test, & ! In
+                                                     l_linear_diffusion, & ! In 
                                                      clubb_config_flags ) ! Out
 
     use model_flags, only: &
@@ -4933,8 +4950,10 @@ contains
     logical, intent(in) :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test 
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations
 
     ! Output variables
     type(clubb_config_flags_type), intent(out) :: &
@@ -4998,6 +5017,7 @@ contains
                                              l_mono_flux_lim_spikefix, & ! In
                                              l_modify_ic_for_cnvg_test, & ! In
                                              l_modify_bc_for_cnvg_test, & ! In 
+                                             l_linear_diffusion, & ! In 
                                              clubb_config_flags ) ! Out
 
   end subroutine initialize_clubb_config_flags_type_api

--- a/src/CLUBB_core/model_flags.F90
+++ b/src/CLUBB_core/model_flags.F90
@@ -276,6 +276,9 @@ module model_flags
       l_mono_flux_lim_vm,           & ! Flag to turn on monotonic flux limiter for vm
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that 
                                       ! eliminates spurious drying tendencies at model top
+    logical :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
 
   end type clubb_config_flags_type
 
@@ -403,7 +406,8 @@ module model_flags
                                              l_mono_flux_lim_rtm, &
                                              l_mono_flux_lim_um, &
                                              l_mono_flux_lim_vm, &
-                                             l_mono_flux_lim_spikefix )
+                                             l_mono_flux_lim_spikefix, &
+                                             l_modify_ic_for_cnvg_test )
 
 ! Description:
 !   Sets all CLUBB flags to a default setting.
@@ -540,6 +544,10 @@ module model_flags
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
 
+    logical, intent(out) :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
+
 !-----------------------------------------------------------------------
     ! Begin code
     ! WARNING: THE DEFAULT VALUES OF THE FLAGS BELOW MAY BE OVERWRITTEN
@@ -605,6 +613,7 @@ module model_flags
     l_mono_flux_lim_um = .true.
     l_mono_flux_lim_vm = .true.
     l_mono_flux_lim_spikefix = .true.
+    l_modify_ic_for_cnvg_test = .false.
 
     return
   end subroutine set_default_clubb_config_flags
@@ -666,6 +675,7 @@ module model_flags
                                                  l_mono_flux_lim_um, &
                                                  l_mono_flux_lim_vm, &
                                                  l_mono_flux_lim_spikefix, &
+                                                 l_modify_ic_for_cnvg_test, &
                                                  clubb_config_flags )
 
 ! Description:
@@ -802,6 +812,9 @@ module model_flags
       l_mono_flux_lim_vm,           & ! Flag to turn on monotonic flux limiter for vm
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
+    logical, intent(in) :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
 
     ! Output variables
     type(clubb_config_flags_type), intent(out) :: &
@@ -866,6 +879,7 @@ module model_flags
     clubb_config_flags%l_mono_flux_lim_um = l_mono_flux_lim_um
     clubb_config_flags%l_mono_flux_lim_vm = l_mono_flux_lim_vm
     clubb_config_flags%l_mono_flux_lim_spikefix = l_mono_flux_lim_spikefix
+    clubb_config_flags%l_modify_ic_for_cnvg_test = l_modify_ic_for_cnvg_test 
 
     return
   end subroutine initialize_clubb_config_flags_type
@@ -949,6 +963,7 @@ module model_flags
     write(iunit,*) "l_mono_flux_lim_um = ",clubb_config_flags%l_mono_flux_lim_vm
     write(iunit,*) "l_mono_flux_lim_vm = ",clubb_config_flags%l_mono_flux_lim_um
     write(iunit,*) "l_mono_flux_lim_spikefix = ",clubb_config_flags%l_mono_flux_lim_spikefix
+    write(iunit,*) "l_modify_ic_for_cnvg_test = ",clubb_config_flags%l_modify_ic_for_cnvg_test
 
     return
   end subroutine print_clubb_config_flags

--- a/src/CLUBB_core/model_flags.F90
+++ b/src/CLUBB_core/model_flags.F90
@@ -279,8 +279,10 @@ module model_flags
     logical :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test 
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations 
 
   end type clubb_config_flags_type
 
@@ -410,7 +412,8 @@ module model_flags
                                              l_mono_flux_lim_vm, &
                                              l_mono_flux_lim_spikefix, &
                                              l_modify_ic_for_cnvg_test, &  
-                                             l_modify_bc_for_cnvg_test )
+                                             l_modify_bc_for_cnvg_test, & 
+                                             l_linear_diffusion )
 
 ! Description:
 !   Sets all CLUBB flags to a default setting.
@@ -550,8 +553,10 @@ module model_flags
     logical, intent(out) :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test 
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations
 
 !-----------------------------------------------------------------------
     ! Begin code
@@ -620,6 +625,7 @@ module model_flags
     l_mono_flux_lim_spikefix = .true.
     l_modify_ic_for_cnvg_test = .false.
     l_modify_bc_for_cnvg_test = .false.
+    l_linear_diffusion = .false. 
 
     return
   end subroutine set_default_clubb_config_flags
@@ -683,6 +689,7 @@ module model_flags
                                                  l_mono_flux_lim_spikefix, &
                                                  l_modify_ic_for_cnvg_test, &
                                                  l_modify_bc_for_cnvg_test, & 
+                                                 l_linear_diffusion, & 
                                                  clubb_config_flags )
 
 ! Description:
@@ -822,8 +829,10 @@ module model_flags
     logical, intent(in) :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test 
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations
 
     ! Output variables
     type(clubb_config_flags_type), intent(out) :: &
@@ -890,6 +899,7 @@ module model_flags
     clubb_config_flags%l_mono_flux_lim_spikefix = l_mono_flux_lim_spikefix
     clubb_config_flags%l_modify_ic_for_cnvg_test = l_modify_ic_for_cnvg_test 
     clubb_config_flags%l_modify_bc_for_cnvg_test = l_modify_bc_for_cnvg_test 
+    clubb_config_flags%l_linear_diffusion = l_linear_diffusion 
 
     return
   end subroutine initialize_clubb_config_flags_type
@@ -975,6 +985,7 @@ module model_flags
     write(iunit,*) "l_mono_flux_lim_spikefix = ",clubb_config_flags%l_mono_flux_lim_spikefix
     write(iunit,*) "l_modify_ic_for_cnvg_test = ",clubb_config_flags%l_modify_ic_for_cnvg_test
     write(iunit,*) "l_modify_bc_for_cnvg_test = ",clubb_config_flags%l_modify_bc_for_cnvg_test 
+    write(iunit,*) "l_linear_diffusion = ",clubb_config_flags%l_linear_diffusion 
 
     return
   end subroutine print_clubb_config_flags

--- a/src/CLUBB_core/model_flags.F90
+++ b/src/CLUBB_core/model_flags.F90
@@ -281,6 +281,8 @@ module model_flags
                                    ! for convergence test 
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations 
 
@@ -413,6 +415,7 @@ module model_flags
                                              l_mono_flux_lim_spikefix, &
                                              l_modify_ic_for_cnvg_test, &  
                                              l_modify_bc_for_cnvg_test, & 
+                                             l_use_modify_limiters, & 
                                              l_linear_diffusion )
 
 ! Description:
@@ -555,6 +558,8 @@ module model_flags
                                    ! for convergence test 
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations
 
@@ -625,6 +630,7 @@ module model_flags
     l_mono_flux_lim_spikefix = .true.
     l_modify_ic_for_cnvg_test = .false.
     l_modify_bc_for_cnvg_test = .false.
+    l_use_modify_limiters = .false.
     l_linear_diffusion = .false. 
 
     return
@@ -688,7 +694,8 @@ module model_flags
                                                  l_mono_flux_lim_vm, &
                                                  l_mono_flux_lim_spikefix, &
                                                  l_modify_ic_for_cnvg_test, &
-                                                 l_modify_bc_for_cnvg_test, & 
+                                                 l_modify_bc_for_cnvg_test, &
+                                                 l_use_modify_limiters, &  
                                                  l_linear_diffusion, & 
                                                  clubb_config_flags )
 
@@ -831,6 +838,8 @@ module model_flags
                                    ! for convergence test 
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations
 
@@ -899,6 +908,7 @@ module model_flags
     clubb_config_flags%l_mono_flux_lim_spikefix = l_mono_flux_lim_spikefix
     clubb_config_flags%l_modify_ic_for_cnvg_test = l_modify_ic_for_cnvg_test 
     clubb_config_flags%l_modify_bc_for_cnvg_test = l_modify_bc_for_cnvg_test 
+    clubb_config_flags%l_use_modify_limiters = l_use_modify_limiters 
     clubb_config_flags%l_linear_diffusion = l_linear_diffusion 
 
     return
@@ -985,6 +995,7 @@ module model_flags
     write(iunit,*) "l_mono_flux_lim_spikefix = ",clubb_config_flags%l_mono_flux_lim_spikefix
     write(iunit,*) "l_modify_ic_for_cnvg_test = ",clubb_config_flags%l_modify_ic_for_cnvg_test
     write(iunit,*) "l_modify_bc_for_cnvg_test = ",clubb_config_flags%l_modify_bc_for_cnvg_test 
+    write(iunit,*) "l_use_modify_limiters = ",clubb_config_flags%l_use_modify_limiters 
     write(iunit,*) "l_linear_diffusion = ",clubb_config_flags%l_linear_diffusion 
 
     return

--- a/src/CLUBB_core/model_flags.F90
+++ b/src/CLUBB_core/model_flags.F90
@@ -277,8 +277,10 @@ module model_flags
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that 
                                       ! eliminates spurious drying tendencies at model top
     logical :: &
-      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                                ! for convergence test 
+      l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                   ! for convergence test 
+      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                   ! for convergence test 
 
   end type clubb_config_flags_type
 
@@ -407,7 +409,8 @@ module model_flags
                                              l_mono_flux_lim_um, &
                                              l_mono_flux_lim_vm, &
                                              l_mono_flux_lim_spikefix, &
-                                             l_modify_ic_for_cnvg_test )
+                                             l_modify_ic_for_cnvg_test, &  
+                                             l_modify_bc_for_cnvg_test )
 
 ! Description:
 !   Sets all CLUBB flags to a default setting.
@@ -545,8 +548,10 @@ module model_flags
                                       ! eliminates spurious drying tendencies at model top
 
     logical, intent(out) :: &
-      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                                ! for convergence test 
+      l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                   ! for convergence test 
+      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                   ! for convergence test 
 
 !-----------------------------------------------------------------------
     ! Begin code
@@ -614,6 +619,7 @@ module model_flags
     l_mono_flux_lim_vm = .true.
     l_mono_flux_lim_spikefix = .true.
     l_modify_ic_for_cnvg_test = .false.
+    l_modify_bc_for_cnvg_test = .false.
 
     return
   end subroutine set_default_clubb_config_flags
@@ -676,6 +682,7 @@ module model_flags
                                                  l_mono_flux_lim_vm, &
                                                  l_mono_flux_lim_spikefix, &
                                                  l_modify_ic_for_cnvg_test, &
+                                                 l_modify_bc_for_cnvg_test, & 
                                                  clubb_config_flags )
 
 ! Description:
@@ -813,8 +820,10 @@ module model_flags
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
     logical, intent(in) :: &
-      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                                ! for convergence test 
+      l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                   ! for convergence test 
+      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                   ! for convergence test 
 
     ! Output variables
     type(clubb_config_flags_type), intent(out) :: &
@@ -880,6 +889,7 @@ module model_flags
     clubb_config_flags%l_mono_flux_lim_vm = l_mono_flux_lim_vm
     clubb_config_flags%l_mono_flux_lim_spikefix = l_mono_flux_lim_spikefix
     clubb_config_flags%l_modify_ic_for_cnvg_test = l_modify_ic_for_cnvg_test 
+    clubb_config_flags%l_modify_bc_for_cnvg_test = l_modify_bc_for_cnvg_test 
 
     return
   end subroutine initialize_clubb_config_flags_type
@@ -964,6 +974,7 @@ module model_flags
     write(iunit,*) "l_mono_flux_lim_vm = ",clubb_config_flags%l_mono_flux_lim_um
     write(iunit,*) "l_mono_flux_lim_spikefix = ",clubb_config_flags%l_mono_flux_lim_spikefix
     write(iunit,*) "l_modify_ic_for_cnvg_test = ",clubb_config_flags%l_modify_ic_for_cnvg_test
+    write(iunit,*) "l_modify_bc_for_cnvg_test = ",clubb_config_flags%l_modify_bc_for_cnvg_test 
 
     return
   end subroutine print_clubb_config_flags

--- a/src/CLUBB_core/version_clubb_core.txt
+++ b/src/CLUBB_core/version_clubb_core.txt
@@ -1,0 +1,128 @@
+commit a0f5313ee697be2153704f9d4b9775cde7d717a1
+Author: huebler <huebler@uwm.edu>
+Date:   Tue Jan 24 12:42:04 2023 -0600
+
+    Fixing error causing GPU code not to run. Some variables to be copied were labelled as (ngrdcol,nz) when it should be (:ngrdcol,:nz). I've just removed the data length specifiers completely since they are not neccesary in general.
+
+commit 95217702784b7eddc848ef0d6f7ee705c10d7752
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Mon Jan 23 19:29:22 2023 -0700
+
+    Adding OpenACC data directives for mixing length and adg routines
+    
+    OpenACC structured data regions are added to optimize the data transfers
+    between CPU and GPU. These data regions will converted to unstrucutred
+    data region in the later optimization phase.
+    Results are bit for bit.
+
+commit f9eb64fb27f4b0515602e0f46848fc644035cfaf
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Fri Jan 20 17:31:54 2023 +0100
+
+    Adds to tuner error bars on bias removal (arrow) plots
+    
+    and also adds bar graphs that show how each parameter contributes to the bias removal.
+
+commit dda5e8c57edb41b73340c0f9578d7c327b18e076
+Author: huebleruwm <37674341+huebleruwm@users.noreply.github.com>
+Date:   Thu Jan 19 12:36:44 2023 -0600
+
+    Adding tridiag_lu solver (#1056)
+    
+    * Adding tridiag_lu solver
+    
+    * Changing low to lower in tridiag_lu and penta_lu, also fixing up some spacing.
+    
+    * Making variables that represent matrix solutions more consistently named.
+
+commit e21e2713eab0f3f228189a4b407c80d4f241038f
+Author: huebleruwm <37674341+huebleruwm@users.noreply.github.com>
+Date:   Thu Jan 19 12:36:21 2023 -0600
+
+    Breaking up column loop in mono_flux_limiter. This may not be the final form for GPUization, but it's definitely a start, no longer do we have to copy single column variables to multicolumn ones anywhere. (#1051)
+
+commit 7f1decd0252e0b4d80f4b3873b0b48b6d3ec8631
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Wed Jan 18 15:36:56 2023 -0700
+
+    Restructuring and Porting of Compute_mixing_length subroutine(Phase 2) (#1054)
+    
+    * Restructuring and Porting of Compute_mixing_length subroutine(Phase 2)
+    
+    Restructure: sat_mixrat_liq_2D_acc is being directly called instead of
+    calling the 1D version inside the column loop. Changing sat_mixrat_liq_2D_acc
+    to a subroutine from a function and adding output array, start_index as
+    additional argument. This is a workaround for passing sub-arrays. The OpenACC
+    doen't like the sub-arrays being passed and fails the validation.
+    
+    Porting: OpenACC directives are added inside sat_mixrat_liq_2D_acc for porting
+    
+    Validation: Answers are Bit for Bit with arm-multicolumn case + nvhpc compiler
+    
+    * Fix for compilation issues
+    
+    Issue 1: Missed out declaring 'start_index' while intergrating the
+    change
+    
+    Issue 2: The use of error_code module and the procedures inside it
+    causes OpenACC compilation issues when run on the device.
+    
+    * Removing the sat_mixrat_liq_acc and sat_mixrat_liq_2D_acc, making the normal sat_mixrat_liq work for all current use cases, and making the other versions of sat_mixrat_liq (bolton,gfdl,lookup) functional with OPENACC.
+    
+    Co-authored-by: huebler <huebler@uwm.edu>
+
+commit 88b8239840f581d76610aa630dab6219d64d68be
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Thu Jan 12 11:54:15 2023 -0700
+
+    Restructuring and Porting of Compute_mixing_length subroutine(Phase 1) (#1052)
+    
+    * Restructuring and Porting of Compute_mixing_length subroutine(Phase 1)
+    
+    Restructure: The compute_mixing_length is one of the top most routine taking 35-50%
+    of the total time in a single timestep. The subroutine has been restructured to
+    push the i-loop further down to extract vectorization and parallelization.
+    The restructuring also involves introduction of sat_mixrat_liq_acc routines to
+    extract parallelism when called inside a OpenACC parallel region.
+    
+    Porting: OpenACC directives are inserted to port the restructured compute_mixing_length
+    code on to the GPUs. This port is currently unoptimized and there is still room for improvement.
+    
+    NOTE: Currently, l_sat_mixrat_lookup = false and saturation_formula = saturation_flatau
+    (Earthworks config options) case is supported on OpenACC build. Any other options works
+    on CPUs as usual. OpenACC declare create directives are inserted in model_flags and
+    constants_clubb, as these module variables are used inside the saturation routines.
+    
+    * Added debug message about only supporting
+    l_sat_mixrat_lookup = false and saturation_formula = saturation_flatau
+     on GPUs
+    Answers are Bit for Bit with arm-multicolumn case + nvhpc compiler.
+    
+    * Changing CLUBB debug level 1 to 0 for the saturation formula support
+    running on GPUs
+    
+    * Changing indentation to make gfortran happy, it wants ifdefs to start at the beginning of the line.
+    
+    * Adding use statements for error checks and printouts, also making the errors set err_code to clubb_fatal_error.
+    
+    Co-authored-by: huebler <huebler@uwm.edu>
+
+commit 6d5d5f573f3866d5d66b028d829342026e569099
+Author: huebler <huebler@uwm.edu>
+Date:   Mon Jan 9 17:09:29 2023 -0600
+
+    Pushing column loop into lapack wrap.
+
+commit ef9acf81f5828bb0d26258d7e2ae2e0ad5959bb5
+Author: huebler <huebler@uwm.edu>
+Date:   Tue Jan 3 14:48:53 2023 -0600
+
+    Adding config script to compile with openacc using nvhpc.
+
+commit 2f930309d0a901cb4ba97ecd7766e81141b29993
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Mon Jan 2 11:57:25 2023 +0100
+
+    Adds to tuner code for min dp for stubborn parameters
+    
+    and adds code to start adding error bars on arrow plots.

--- a/src/G_unit_test_types/pdf_parameter_tests.F90
+++ b/src/G_unit_test_types/pdf_parameter_tests.F90
@@ -551,8 +551,10 @@ module pdf_parameter_tests
                                       ! eliminates spurious drying tendencies at model top
 
     logical :: &
-      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                                ! for convergence test 
+      l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                   ! for convergence test 
+      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                   ! for convergence test 
 
     real( kind = core_rknd ) :: & 
       C1, C1b, C1c, C2rt, C2thl, C2rtthl, & 
@@ -697,7 +699,8 @@ module pdf_parameter_tests
                                          l_mono_flux_lim_um, &
                                          l_mono_flux_lim_vm, &
                                          l_mono_flux_lim_spikefix, &
-                                         l_modify_ic_for_cnvg_test )
+                                         l_modify_ic_for_cnvg_test, &
+                                         l_modify_bc_for_cnvg_test )
 
     iiPDF_type = test_pdf_type
 

--- a/src/G_unit_test_types/pdf_parameter_tests.F90
+++ b/src/G_unit_test_types/pdf_parameter_tests.F90
@@ -555,6 +555,8 @@ module pdf_parameter_tests
                                    ! for convergence test 
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations
 
@@ -703,6 +705,7 @@ module pdf_parameter_tests
                                          l_mono_flux_lim_spikefix, &
                                          l_modify_ic_for_cnvg_test, &
                                          l_modify_bc_for_cnvg_test, & 
+                                         l_use_modify_limiters, & 
                                          l_linear_diffusion )
 
     iiPDF_type = test_pdf_type

--- a/src/G_unit_test_types/pdf_parameter_tests.F90
+++ b/src/G_unit_test_types/pdf_parameter_tests.F90
@@ -550,6 +550,10 @@ module pdf_parameter_tests
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
 
+    logical :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
+
     real( kind = core_rknd ) :: & 
       C1, C1b, C1c, C2rt, C2thl, C2rtthl, & 
       C4, C_uu_shr, C_uu_buoy, C6rt, C6rtb, C6rtc, C6thl, C6thlb, C6thlc, & 
@@ -692,7 +696,8 @@ module pdf_parameter_tests
                                          l_mono_flux_lim_rtm, &
                                          l_mono_flux_lim_um, &
                                          l_mono_flux_lim_vm, &
-                                         l_mono_flux_lim_spikefix )
+                                         l_mono_flux_lim_spikefix, &
+                                         l_modify_ic_for_cnvg_test )
 
     iiPDF_type = test_pdf_type
 

--- a/src/G_unit_test_types/pdf_parameter_tests.F90
+++ b/src/G_unit_test_types/pdf_parameter_tests.F90
@@ -553,8 +553,10 @@ module pdf_parameter_tests
     logical :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test 
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations
 
     real( kind = core_rknd ) :: & 
       C1, C1b, C1c, C2rt, C2thl, C2rtthl, & 
@@ -700,7 +702,8 @@ module pdf_parameter_tests
                                          l_mono_flux_lim_vm, &
                                          l_mono_flux_lim_spikefix, &
                                          l_modify_ic_for_cnvg_test, &
-                                         l_modify_bc_for_cnvg_test )
+                                         l_modify_bc_for_cnvg_test, & 
+                                         l_linear_diffusion )
 
     iiPDF_type = test_pdf_type
 

--- a/src/G_unit_test_types/spurious_source_test.F90
+++ b/src/G_unit_test_types/spurious_source_test.F90
@@ -495,6 +495,8 @@ module spurious_source_test
                                    ! for convergence test 
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations
 
@@ -619,6 +621,7 @@ module spurious_source_test
                                          l_mono_flux_lim_spikefix, &
                                          l_modify_ic_for_cnvg_test, & 
                                          l_modify_bc_for_cnvg_test, &
+                                         l_use_modify_limiters, & 
                                          l_linear_diffusion )
                                          
     ! Initialize pdf_implicit_coefs_terms

--- a/src/G_unit_test_types/spurious_source_test.F90
+++ b/src/G_unit_test_types/spurious_source_test.F90
@@ -493,8 +493,10 @@ module spurious_source_test
     logical :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test 
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations
 
     integer, parameter :: &
       order_xm_wpxp = 1, &
@@ -616,7 +618,8 @@ module spurious_source_test
                                          l_mono_flux_lim_vm, &
                                          l_mono_flux_lim_spikefix, &
                                          l_modify_ic_for_cnvg_test, & 
-                                         l_modify_bc_for_cnvg_test )
+                                         l_modify_bc_for_cnvg_test, &
+                                         l_linear_diffusion )
                                          
     ! Initialize pdf_implicit_coefs_terms
     call init_pdf_implicit_coefs_terms( nz, 1, sclr_dim, &

--- a/src/G_unit_test_types/spurious_source_test.F90
+++ b/src/G_unit_test_types/spurious_source_test.F90
@@ -490,6 +490,10 @@ module spurious_source_test
       l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                       ! eliminates spurious drying tendencies at model top
 
+    logical :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
+
     integer, parameter :: &
       order_xm_wpxp = 1, &
       order_xp2_xpyp = 2, &
@@ -608,7 +612,8 @@ module spurious_source_test
                                          l_mono_flux_lim_rtm, &
                                          l_mono_flux_lim_um, &
                                          l_mono_flux_lim_vm, &
-                                         l_mono_flux_lim_spikefix )
+                                         l_mono_flux_lim_spikefix, &
+                                         l_modify_ic_for_cnvg_test )
                                          
     ! Initialize pdf_implicit_coefs_terms
     call init_pdf_implicit_coefs_terms( nz, 1, sclr_dim, &

--- a/src/G_unit_test_types/spurious_source_test.F90
+++ b/src/G_unit_test_types/spurious_source_test.F90
@@ -491,8 +491,10 @@ module spurious_source_test
                                       ! eliminates spurious drying tendencies at model top
 
     logical :: &
-      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                                ! for convergence test 
+      l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                   ! for convergence test 
+      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                   ! for convergence test 
 
     integer, parameter :: &
       order_xm_wpxp = 1, &
@@ -613,7 +615,8 @@ module spurious_source_test
                                          l_mono_flux_lim_um, &
                                          l_mono_flux_lim_vm, &
                                          l_mono_flux_lim_spikefix, &
-                                         l_modify_ic_for_cnvg_test )
+                                         l_modify_ic_for_cnvg_test, & 
+                                         l_modify_bc_for_cnvg_test )
                                          
     ! Initialize pdf_implicit_coefs_terms
     call init_pdf_implicit_coefs_terms( nz, 1, sclr_dim, &

--- a/src/SILHS/version_silhs.txt
+++ b/src/SILHS/version_silhs.txt
@@ -1,0 +1,128 @@
+commit a0f5313ee697be2153704f9d4b9775cde7d717a1
+Author: huebler <huebler@uwm.edu>
+Date:   Tue Jan 24 12:42:04 2023 -0600
+
+    Fixing error causing GPU code not to run. Some variables to be copied were labelled as (ngrdcol,nz) when it should be (:ngrdcol,:nz). I've just removed the data length specifiers completely since they are not neccesary in general.
+
+commit 95217702784b7eddc848ef0d6f7ee705c10d7752
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Mon Jan 23 19:29:22 2023 -0700
+
+    Adding OpenACC data directives for mixing length and adg routines
+    
+    OpenACC structured data regions are added to optimize the data transfers
+    between CPU and GPU. These data regions will converted to unstrucutred
+    data region in the later optimization phase.
+    Results are bit for bit.
+
+commit f9eb64fb27f4b0515602e0f46848fc644035cfaf
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Fri Jan 20 17:31:54 2023 +0100
+
+    Adds to tuner error bars on bias removal (arrow) plots
+    
+    and also adds bar graphs that show how each parameter contributes to the bias removal.
+
+commit dda5e8c57edb41b73340c0f9578d7c327b18e076
+Author: huebleruwm <37674341+huebleruwm@users.noreply.github.com>
+Date:   Thu Jan 19 12:36:44 2023 -0600
+
+    Adding tridiag_lu solver (#1056)
+    
+    * Adding tridiag_lu solver
+    
+    * Changing low to lower in tridiag_lu and penta_lu, also fixing up some spacing.
+    
+    * Making variables that represent matrix solutions more consistently named.
+
+commit e21e2713eab0f3f228189a4b407c80d4f241038f
+Author: huebleruwm <37674341+huebleruwm@users.noreply.github.com>
+Date:   Thu Jan 19 12:36:21 2023 -0600
+
+    Breaking up column loop in mono_flux_limiter. This may not be the final form for GPUization, but it's definitely a start, no longer do we have to copy single column variables to multicolumn ones anywhere. (#1051)
+
+commit 7f1decd0252e0b4d80f4b3873b0b48b6d3ec8631
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Wed Jan 18 15:36:56 2023 -0700
+
+    Restructuring and Porting of Compute_mixing_length subroutine(Phase 2) (#1054)
+    
+    * Restructuring and Porting of Compute_mixing_length subroutine(Phase 2)
+    
+    Restructure: sat_mixrat_liq_2D_acc is being directly called instead of
+    calling the 1D version inside the column loop. Changing sat_mixrat_liq_2D_acc
+    to a subroutine from a function and adding output array, start_index as
+    additional argument. This is a workaround for passing sub-arrays. The OpenACC
+    doen't like the sub-arrays being passed and fails the validation.
+    
+    Porting: OpenACC directives are added inside sat_mixrat_liq_2D_acc for porting
+    
+    Validation: Answers are Bit for Bit with arm-multicolumn case + nvhpc compiler
+    
+    * Fix for compilation issues
+    
+    Issue 1: Missed out declaring 'start_index' while intergrating the
+    change
+    
+    Issue 2: The use of error_code module and the procedures inside it
+    causes OpenACC compilation issues when run on the device.
+    
+    * Removing the sat_mixrat_liq_acc and sat_mixrat_liq_2D_acc, making the normal sat_mixrat_liq work for all current use cases, and making the other versions of sat_mixrat_liq (bolton,gfdl,lookup) functional with OPENACC.
+    
+    Co-authored-by: huebler <huebler@uwm.edu>
+
+commit 88b8239840f581d76610aa630dab6219d64d68be
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Thu Jan 12 11:54:15 2023 -0700
+
+    Restructuring and Porting of Compute_mixing_length subroutine(Phase 1) (#1052)
+    
+    * Restructuring and Porting of Compute_mixing_length subroutine(Phase 1)
+    
+    Restructure: The compute_mixing_length is one of the top most routine taking 35-50%
+    of the total time in a single timestep. The subroutine has been restructured to
+    push the i-loop further down to extract vectorization and parallelization.
+    The restructuring also involves introduction of sat_mixrat_liq_acc routines to
+    extract parallelism when called inside a OpenACC parallel region.
+    
+    Porting: OpenACC directives are inserted to port the restructured compute_mixing_length
+    code on to the GPUs. This port is currently unoptimized and there is still room for improvement.
+    
+    NOTE: Currently, l_sat_mixrat_lookup = false and saturation_formula = saturation_flatau
+    (Earthworks config options) case is supported on OpenACC build. Any other options works
+    on CPUs as usual. OpenACC declare create directives are inserted in model_flags and
+    constants_clubb, as these module variables are used inside the saturation routines.
+    
+    * Added debug message about only supporting
+    l_sat_mixrat_lookup = false and saturation_formula = saturation_flatau
+     on GPUs
+    Answers are Bit for Bit with arm-multicolumn case + nvhpc compiler.
+    
+    * Changing CLUBB debug level 1 to 0 for the saturation formula support
+    running on GPUs
+    
+    * Changing indentation to make gfortran happy, it wants ifdefs to start at the beginning of the line.
+    
+    * Adding use statements for error checks and printouts, also making the errors set err_code to clubb_fatal_error.
+    
+    Co-authored-by: huebler <huebler@uwm.edu>
+
+commit 6d5d5f573f3866d5d66b028d829342026e569099
+Author: huebler <huebler@uwm.edu>
+Date:   Mon Jan 9 17:09:29 2023 -0600
+
+    Pushing column loop into lapack wrap.
+
+commit ef9acf81f5828bb0d26258d7e2ae2e0ad5959bb5
+Author: huebler <huebler@uwm.edu>
+Date:   Tue Jan 3 14:48:53 2023 -0600
+
+    Adding config script to compile with openacc using nvhpc.
+
+commit 2f930309d0a901cb4ba97ecd7766e81141b29993
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Mon Jan 2 11:57:25 2023 +0100
+
+    Adds to tuner code for min dp for stubborn parameters
+    
+    and adds code to start adding error bars on arrow plots.

--- a/src/clubb_driver.F90
+++ b/src/clubb_driver.F90
@@ -846,8 +846,10 @@ module clubb_driver
     logical :: &
       l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                    ! for convergence test
-      l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+      l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                   ! as numerical smoothing in clubb equations
 
     type(clubb_config_flags_type) :: &
       clubb_config_flags ! Derived type holding all configurable CLUBB flags
@@ -898,7 +900,7 @@ module clubb_driver
       l_use_tke_in_wp2_wp3_K_dfsn, l_smooth_Heaviside_tau_wpxp, &
       l_enable_relaxed_clipping, l_linearize_pbl_winds, l_mono_flux_lim_thlm, &
       l_mono_flux_lim_rtm, l_mono_flux_lim_um, l_mono_flux_lim_vm, l_mono_flux_lim_spikefix, & 
-      l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test 
+      l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test, l_linear_diffusion 
 
     integer :: &
       err_code_dummy ! Host models use an error code that comes out of some API routines, but
@@ -1066,7 +1068,8 @@ module clubb_driver
                                          l_mono_flux_lim_vm, & ! Intent(out)
                                          l_mono_flux_lim_spikefix, & ! Intent(out) 
                                          l_modify_ic_for_cnvg_test, & ! Intent(out)
-                                         l_modify_bc_for_cnvg_test ) ! Intent(out)
+                                         l_modify_bc_for_cnvg_test, & ! Intent(out)
+                                         l_linear_diffusion ) ! Intent(out)
 
     ! Read namelist file
     open(unit=iunit, file=trim( runfile ), status='old')
@@ -1463,6 +1466,7 @@ module clubb_driver
                                              l_mono_flux_lim_spikefix, & ! Intent(in)
                                              l_modify_ic_for_cnvg_test, & ! Intent(in)
                                              l_modify_bc_for_cnvg_test, & ! Intent(in)
+                                             l_linear_diffusion, & ! Intent(in)
                                              clubb_config_flags ) ! Intent(out)
 
     ! Printing configurable CLUBB flags Inputs
@@ -1517,6 +1521,7 @@ module clubb_driver
            grid_type, momentum_heights(begin_height:end_height), & ! intent(in)
            thermodynamic_heights(begin_height:end_height),       & ! intent(in)
            l_prescribed_avg_deltaz,                              & ! intent(in)
+           clubb_config_flags%l_linear_diffusion,                & ! intent(in)
            lmin, nu_vert_res_dep, err_code_dummy )                 ! intent(out)  
 
     ! Allocate and initialize variables
@@ -6956,6 +6961,7 @@ module clubb_driver
              grid_type, momentum_heights_col(:,begin_height:end_height),          & ! intent(in)
              thermodynamic_heights_col(:,begin_height:end_height),                & ! intent(in)
              l_prescribed_avg_deltaz,                                             & ! intent(in)
+             clubb_config_flags%l_linear_diffusion,                               & ! intent(in)
              lmin_col, nu_vert_res_dep_col, err_code_dummy )                        ! intent(out)  
 
       ! Allocate the inouts we want to save

--- a/src/clubb_driver.F90
+++ b/src/clubb_driver.F90
@@ -848,6 +848,8 @@ module clubb_driver
                                    ! for convergence test
       l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                    ! for convergence test 
+      l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                   ! the solution convergence 
       l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                    ! as numerical smoothing in clubb equations
 
@@ -900,7 +902,8 @@ module clubb_driver
       l_use_tke_in_wp2_wp3_K_dfsn, l_smooth_Heaviside_tau_wpxp, &
       l_enable_relaxed_clipping, l_linearize_pbl_winds, l_mono_flux_lim_thlm, &
       l_mono_flux_lim_rtm, l_mono_flux_lim_um, l_mono_flux_lim_vm, l_mono_flux_lim_spikefix, & 
-      l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test, l_linear_diffusion 
+      l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test, l_use_modify_limiters, & 
+      l_linear_diffusion 
 
     integer :: &
       err_code_dummy ! Host models use an error code that comes out of some API routines, but
@@ -1069,6 +1072,7 @@ module clubb_driver
                                          l_mono_flux_lim_spikefix, & ! Intent(out) 
                                          l_modify_ic_for_cnvg_test, & ! Intent(out)
                                          l_modify_bc_for_cnvg_test, & ! Intent(out)
+                                         l_use_modify_limiters, & ! Intent(out)
                                          l_linear_diffusion ) ! Intent(out)
 
     ! Read namelist file
@@ -1466,6 +1470,7 @@ module clubb_driver
                                              l_mono_flux_lim_spikefix, & ! Intent(in)
                                              l_modify_ic_for_cnvg_test, & ! Intent(in)
                                              l_modify_bc_for_cnvg_test, & ! Intent(in)
+                                             l_use_modify_limiters, & ! Intent(in)
                                              l_linear_diffusion, & ! Intent(in)
                                              clubb_config_flags ) ! Intent(out)
 

--- a/src/clubb_tuner.F90
+++ b/src/clubb_tuner.F90
@@ -672,8 +672,10 @@ subroutine logical_flags_driver( current_date, current_time )
                                     ! eliminates spurious drying tendencies at model top
 
   logical :: &
-    l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
-                              ! for convergence test 
+    l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
+                                 ! for convergence test 
+    l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+                                 ! for convergence test 
 
   namelist /configurable_clubb_flags_nl/ &
     iiPDF_type, ipdf_call_placement, penta_solve_method, tridiag_solve_method, &
@@ -690,7 +692,7 @@ subroutine logical_flags_driver( current_date, current_time )
     l_brunt_vaisala_freq_moist, l_use_thvm_in_bv_freq, &
     l_lmm_stepping, l_e3sm_config, l_vary_convect_depth, l_use_tke_in_wp3_pr_turb_term, &
     l_use_tke_in_wp2_wp3_K_dfsn, l_smooth_Heaviside_tau_wpxp, &
-    l_modify_ic_for_cnvg_test 
+    l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test 
 
   ! ---- Begin Code ----
 
@@ -750,7 +752,8 @@ subroutine logical_flags_driver( current_date, current_time )
                                        l_mono_flux_lim_um, & ! Intent(out)
                                        l_mono_flux_lim_vm, & ! Intent(out)
                                        l_mono_flux_lim_spikefix, & ! Intent(out) 
-                                       l_modify_ic_for_cnvg_test ) ! Intent(out)
+                                       l_modify_ic_for_cnvg_test, & ! Intent(out) 
+                                       l_modify_bc_for_cnvg_test ) ! Intent(out)
 
   ! Determine the current flags
   model_flags_default(1) = l_godunov_upwind_wpxp_ta

--- a/src/clubb_tuner.F90
+++ b/src/clubb_tuner.F90
@@ -671,6 +671,10 @@ subroutine logical_flags_driver( current_date, current_time )
     l_mono_flux_lim_spikefix        ! Flag to implement monotonic flux limiter code that
                                     ! eliminates spurious drying tendencies at model top
 
+  logical :: &
+    l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                              ! for convergence test 
+
   namelist /configurable_clubb_flags_nl/ &
     iiPDF_type, ipdf_call_placement, penta_solve_method, tridiag_solve_method, &
     l_upwind_xpyp_ta, l_upwind_xm_ma, l_quintic_poly_interp, &
@@ -685,7 +689,8 @@ subroutine logical_flags_driver( current_date, current_time )
     l_trapezoidal_rule_zm, l_call_pdf_closure_twice, l_Lscale_plume_centered, &
     l_brunt_vaisala_freq_moist, l_use_thvm_in_bv_freq, &
     l_lmm_stepping, l_e3sm_config, l_vary_convect_depth, l_use_tke_in_wp3_pr_turb_term, &
-    l_use_tke_in_wp2_wp3_K_dfsn, l_smooth_Heaviside_tau_wpxp
+    l_use_tke_in_wp2_wp3_K_dfsn, l_smooth_Heaviside_tau_wpxp, &
+    l_modify_ic_for_cnvg_test 
 
   ! ---- Begin Code ----
 
@@ -744,7 +749,8 @@ subroutine logical_flags_driver( current_date, current_time )
                                        l_mono_flux_lim_rtm, & ! Intent(out)
                                        l_mono_flux_lim_um, & ! Intent(out)
                                        l_mono_flux_lim_vm, & ! Intent(out)
-                                       l_mono_flux_lim_spikefix ) ! Intent(out)
+                                       l_mono_flux_lim_spikefix, & ! Intent(out) 
+                                       l_modify_ic_for_cnvg_test ) ! Intent(out)
 
   ! Determine the current flags
   model_flags_default(1) = l_godunov_upwind_wpxp_ta

--- a/src/clubb_tuner.F90
+++ b/src/clubb_tuner.F90
@@ -674,8 +674,10 @@ subroutine logical_flags_driver( current_date, current_time )
   logical :: &
     l_modify_ic_for_cnvg_test, & ! Flag to activate modifications on initial condition 
                                  ! for convergence test 
-    l_modify_bc_for_cnvg_test    ! Flag to activate modifications on boundary condition 
+    l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                  ! for convergence test 
+    l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
+                                 ! as numerical smoothing in clubb equations
 
   namelist /configurable_clubb_flags_nl/ &
     iiPDF_type, ipdf_call_placement, penta_solve_method, tridiag_solve_method, &
@@ -692,7 +694,7 @@ subroutine logical_flags_driver( current_date, current_time )
     l_brunt_vaisala_freq_moist, l_use_thvm_in_bv_freq, &
     l_lmm_stepping, l_e3sm_config, l_vary_convect_depth, l_use_tke_in_wp3_pr_turb_term, &
     l_use_tke_in_wp2_wp3_K_dfsn, l_smooth_Heaviside_tau_wpxp, &
-    l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test 
+    l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test, l_linear_diffusion 
 
   ! ---- Begin Code ----
 
@@ -753,7 +755,8 @@ subroutine logical_flags_driver( current_date, current_time )
                                        l_mono_flux_lim_vm, & ! Intent(out)
                                        l_mono_flux_lim_spikefix, & ! Intent(out) 
                                        l_modify_ic_for_cnvg_test, & ! Intent(out) 
-                                       l_modify_bc_for_cnvg_test ) ! Intent(out)
+                                       l_modify_bc_for_cnvg_test, & ! Intent(out) 
+                                       l_linear_diffusion ) ! Intent(out)
 
   ! Determine the current flags
   model_flags_default(1) = l_godunov_upwind_wpxp_ta

--- a/src/clubb_tuner.F90
+++ b/src/clubb_tuner.F90
@@ -676,6 +676,8 @@ subroutine logical_flags_driver( current_date, current_time )
                                  ! for convergence test 
     l_modify_bc_for_cnvg_test, & ! Flag to activate modifications on boundary condition 
                                  ! for convergence test 
+    l_use_modify_limiters,     & ! Flag to activate modifications on limiters to improve 
+                                 ! the solution convergence 
     l_linear_diffusion           ! Flag to use linear diffusion instead of nonlinear diffusion 
                                  ! as numerical smoothing in clubb equations
 
@@ -694,7 +696,8 @@ subroutine logical_flags_driver( current_date, current_time )
     l_brunt_vaisala_freq_moist, l_use_thvm_in_bv_freq, &
     l_lmm_stepping, l_e3sm_config, l_vary_convect_depth, l_use_tke_in_wp3_pr_turb_term, &
     l_use_tke_in_wp2_wp3_K_dfsn, l_smooth_Heaviside_tau_wpxp, &
-    l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test, l_linear_diffusion 
+    l_modify_ic_for_cnvg_test, l_modify_bc_for_cnvg_test, l_use_modify_limiters, & 
+    l_linear_diffusion 
 
   ! ---- Begin Code ----
 
@@ -756,6 +759,7 @@ subroutine logical_flags_driver( current_date, current_time )
                                        l_mono_flux_lim_spikefix, & ! Intent(out) 
                                        l_modify_ic_for_cnvg_test, & ! Intent(out) 
                                        l_modify_bc_for_cnvg_test, & ! Intent(out) 
+                                       l_use_modify_limiters, & ! Intent(out)
                                        l_linear_diffusion ) ! Intent(out)
 
   ! Determine the current flags

--- a/src/sounding.F90
+++ b/src/sounding.F90
@@ -87,7 +87,7 @@ module sounding
     intrinsic :: trim, exp
 
     ! Constant parameter
-    integer, parameter :: nmaxsnd = 600
+    integer, parameter :: nmaxsnd = 10000
 
     ! Input variables
     integer, intent(in) :: iunit ! File unit to use for namelist

--- a/src/sounding.F90
+++ b/src/sounding.F90
@@ -23,9 +23,10 @@ module sounding
   contains
   !------------------------------------------------------------------------
   subroutine read_sounding( gr, iunit, runtype, p_sfc, zm_init,& 
+                            l_modify_ic_for_cnvg_test, & 
                             thlm, theta_type, rtm, um, vm, ugm, vgm, &
                             alt_type, press, subs_type, wm, &
-                            rtm_sfc, thlm_sfc, sclrm, edsclrm )
+                            rtm_sfc, thlm_sfc, sclrm, edsclrm ) 
 
     ! Description:
     !   Subroutine to initialize model variables from a namelist file
@@ -44,6 +45,7 @@ module sounding
 
     use interpolation, only:  & 
         lin_interpolate_two_points, & ! Procedure(s)
+        mono_cubic_interp, &
         binary_search
 
     use array_index, only: & 
@@ -93,6 +95,9 @@ module sounding
     character(len=*), intent(in) ::  & 
       runtype ! Used to determine if this in a DYCOMS II RF02 simulation
 
+    logical, intent(in) :: &
+      l_modify_ic_for_cnvg_test ! Flag to activate modifications on initial condition 
+                                ! for convergence test 
 
     real( kind = core_rknd ), intent(in) :: &
       p_sfc, & ! Pressure at the surface [Pa]
@@ -155,6 +160,8 @@ module sounding
       sclr_sounding_retVars ! Sclr Sounding Profile
 
     integer :: i, j, k  ! Loop indices
+
+    integer :: km1, kp1, kp2, k00 ! For mono cubic interpolation 
 
     integer :: idx  ! Result of binary search -- sounding level index.
 
@@ -320,29 +327,107 @@ module sounding
         end if  ! k > nlevels
 
         ! Regular situation w/ linear int.
-        IF ( trim( runtype ) /= "dycoms2_rf02" ) THEN
+        IF ( trim( runtype ) /= "dycoms2_rf02" .or. l_modify_ic_for_cnvg_test ) THEN
 
-          um(i)   = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), u(k), u(k-1) )
-          vm(i)   = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), v(k), v(k-1) )
-          ugm(i)  = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), ug(k), ug(k-1) )
-          vgm(i)  = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), vg(k), vg(k-1) )
-          thlm(i) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), theta(k), theta(k-1) )
-          rtm(i)  = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), rt(k), rt(k-1) )
-          press(i) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), p_in_Pa(k), p_in_Pa(k-1) )
-          wm(i) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), subs(k), subs(k-1) )
+          if (l_modify_ic_for_cnvg_test) then 
+            !use Steffen's monotone cubic interpolation method to obtain
+            !smoothing initial condition profile for convergence test 
+            if ( k == gr%nz ) then
+              km1 = k-2
+              kp1 = k
+              kp2 = k
+              k00 = k-1
+            else if ( k == 2 ) then
+              km1 = 1
+              kp1 = 2
+              kp2 = 3
+              k00 = 1
+            else if ( k == 1 ) then ! Extrapolation for the ghost point
+              km1 = k
+              k00 = 1
+              kp1 = 2
+              kp2 = 3
+            else
+              km1 = k-2
+              kp1 = k
+              kp2 = k+1
+              k00 = k-1
+            end if
+            um(i)    = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), & 
+                                          z(kp2), u(km1), u(k00), u(kp1), u(kp2) )
+            vm(i)    = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), &
+                                          z(kp2), v(km1), v(k00), v(kp1), v(kp2) )
+            ugm(i)   = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), &
+                                          z(kp2), ug(km1), ug(k00), ug(kp1), ug(kp2) )
+            vgm(i)   = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), &
+                                          z(kp2), vg(km1), vg(k00), vg(kp1), vg(kp2) )
+            thlm(i)  = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), &
+                                          z(kp2), theta(km1), theta(k00), theta(kp1), theta(kp2) )
+            rtm(i)   = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), &
+                                          z(kp2), rt(km1), rt(k00), rt(kp1), rt(kp2) )
+            press(i) = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), &
+                                          z(kp2), p_in_Pa(km1), p_in_Pa(k00), p_in_Pa(kp1), p_in_Pa(kp2) )
+            wm(i)    = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, z(km1), z(k00), z(kp1), &
+                                          z(kp2), subs(km1), subs(k00), subs(kp1), subs(kp2) )
+ 
+            if ( trim( runtype ) /= "dycoms2_rf02" ) then 
+              if ( sclr_dim > 0 ) then
+                do j = 1, sclr_dim
+                  sclrm(i,j) = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, & 
+                                                  z(km1), z(k00), z(kp1), z(kp2), & 
+                                                  sclr(km1,j), sclr(k00,j), &
+                                                  sclr(kp1,j), sclr(kp2,j) )
+                end do
+              end if
+              if ( edsclr_dim > 0 ) then
+                do j = 1, edsclr_dim
+                  edsclrm(i,j) = mono_cubic_interp( gr%zt(1,i), km1, k00, kp1, kp2, & 
+                                                    z(km1), z(k00), z(kp1), z(kp2), & 
+                                                    edsclr(km1,j), edsclr(k00,j), &
+                                                    edsclr(kp1,j), edsclr(kp2,j) )
+                end do
+              end if
+            else 
+              ! modified IC for DYCOMS2_RF02 case (same as default setup below)
+              ugm(i)  = um(i)
+              vgm(i)  = vm(i)
+              ! Passive Scalars
+              ! Change this if they are not equal to theta_l and rt in RF02
+              if ( iisclr_thl > 0  ) then
+                sclrm(i, iisclr_thl)   = thlm(i)
+                edsclrm(i, iisclr_thl) = thlm(i)
+              end if
+              if ( iisclr_rt > 0 ) then
+                sclrm(i, iisclr_rt)    = rtm(i)
+                edsclrm(i, iisclr_rt)  = rtm(i)
+              end if
+            end if  
 
-          if ( sclr_dim > 0 ) then
-            do j = 1, sclr_dim
-              sclrm(i,j) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1),  & 
-                                    sclr(k,j), sclr(k-1,j) )
-            end do
-          end if
-          if ( edsclr_dim > 0 ) then
-            do j = 1, edsclr_dim
-              edsclrm(i,j) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1),  & 
-                                      edsclr(k,j), edsclr(k-1,j) )
-            end do
-          end if
+          else 
+
+            um(i)   = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), u(k), u(k-1) )
+            vm(i)   = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), v(k), v(k-1) )
+            ugm(i)  = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), ug(k), ug(k-1) )
+            vgm(i)  = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), vg(k), vg(k-1) )
+            thlm(i) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), theta(k), theta(k-1) )
+            rtm(i)  = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), rt(k), rt(k-1) )
+            press(i) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), p_in_Pa(k), p_in_Pa(k-1) )
+            wm(i) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1), subs(k), subs(k-1) )
+
+            if ( sclr_dim > 0 ) then
+              do j = 1, sclr_dim
+                sclrm(i,j) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1),  & 
+                                      sclr(k,j), sclr(k-1,j) )
+              end do
+            end if
+            if ( edsclr_dim > 0 ) then
+              do j = 1, edsclr_dim
+                edsclrm(i,j) = lin_interpolate_two_points( gr%zt(1,i), z(k), z(k-1),  & 
+                                        edsclr(k,j), edsclr(k-1,j) )
+              end do
+            end if
+
+          end if 
 
         ELSE  ! DYCOMS II RF02 case
 


### PR DESCRIPTION
This commit contains code changes to implement modifications on limiters in three places:
1. remove the limiters in the denominator of the equation for brunt_vaisala_freq_sqd_smth, which affects the computed eddy dissipation time scale in turbulent fluxes (wpxp). (mixing_length.F90)
2. reduce the threshold values of limiters in the equation for Richardson number (sqrt_Ri_zm) (mixing_length.F90).
4. introduce the smoothed max/min function for limiters in the equation of Cx_fnc_Richardson (advance_helper_module.F90).

    The modified files for this implementation include:
      ../src/CLUBB_core/advance_clubb_core_module.F90
      ../src/CLUBB_core/clubb_api_module.F90
      ../src/CLUBB_core/model_flags.F90
      ../src/CLUBB_core/advance_helper_module.F90
      ../src/CLUBB_core/mixing_length.F90
      ../src/G_unit_test_types/pdf_parameter_tests.F90
      ../src/G_unit_test_types/spurious_source_test.F90
      ../src/clubb_driver.F90
      ../src/clubb_tuner.F90