### PR TITLE
Revised boundary conditions for convergence test simulation 

### DIFF
--- a/run_scripts/convergence_run/convergence_config.py
+++ b/run_scripts/convergence_run/convergence_config.py
@@ -1,0 +1,431 @@
+#!/usr/bin/python
+#######################################################################
+# $Id$
+#
+# Description:
+# Script to configure and run convergence test simulations.   
+# The script only well tested for BOMEX, RICO, DYCOMS2_RF02 and Wangara cases 
+# original script developer: Chris Vogl (vogl2@llnl.gov)
+# revised by Shixuan Zhang (shixuan.zhang@pnnl.gov) 
+#
+#######################################################################
+import argparse
+import numpy as np
+import os
+import sys
+import shutil
+from convergence_function import modify_ic_profile
+
+# check that Python 3 is being used
+if (sys.version_info.major < 3):
+  sys.exit('must use Python 3 instead of {}'.format(sys.version))
+
+# get CLUBB root directory (assumed to be one above the CWD) and set directories
+clubb_dir = os.path.join(os.getcwd(),'..')
+output_dir = os.path.join(clubb_dir, 'output')
+case_dir = os.path.join(clubb_dir, 'input', 'case_setups')
+grid_dir = os.path.join(clubb_dir, 'input', 'grid')
+tunable_dir = os.path.join(clubb_dir, 'input', 'tunable_parameters')
+stats_dir = os.path.join(clubb_dir, 'input', 'stats')
+bin_dir = os.path.join(clubb_dir, 'bin')
+res_dir = os.path.join(clubb_dir, 'restart_ic') 
+
+# remind user to load modules if this is Quartz
+if ('quartz' in os.uname().nodename):
+  print('########################################################')
+  print('  make sure to load the mkl and netcdf-fortran modules  ')
+  print('########################################################')
+
+# parse command line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('case',
+  help='name of case to run', choices=('rico', 'bomex', 'wangara', 'dycoms2_rf02_nd'))
+parser.add_argument ('-dt', metavar='seconds',
+  help='timestep size')
+parser.add_argument('-dto', metavar='seconds', dest='dt_output',
+  help='time interval between output (default is max[600,dt] if dt specified)')
+parser.add_argument('-dz', metavar='meters',
+  help='use a uniform grid with specified dz')
+parser.add_argument('-Tsfc', dest='Tsfc', action='store_true',
+  help='note that the Tscf in the sounding file has been modified (user must have modified file)')
+parser.add_argument('-ti', metavar='seconds', dest='tinitial',
+  help='time (in seconds) to simulate')
+parser.add_argument('-tf', metavar='seconds', dest='tfinal',
+  help='time (in seconds) to simulate')
+parser.add_argument('-ref', metavar='num', dest='refine',
+  help='use a stretched grid with specified number of refinement')
+parser.add_argument('-output-name',dest='output_name',
+  help='use user specified naming convention instead of one generated from other flags')
+parser.add_argument('-micro-off', dest='turn_off_microphysics', action='store_true',
+  help='turn off microphysics instead of using default case setups')
+parser.add_argument('-rad-off', dest='turn_off_radiation', action='store_true',
+  help='turn off radiation scheme instead of using default case setup')
+parser.add_argument('-binary-out', dest='default_format', action='store_true',
+  help='use output format in default case setup (binary) instead of netcdf')
+parser.add_argument('-new-bc', dest='modified_bc', action='store_true',
+  help='use boundary condition at fixed height instead of method in default case setup (space dependent)')
+parser.add_argument('-new-ic', dest='modified_ic', action='store_true',
+  help='use smoothed initial condition instead of method in default case setup (linear interpolation)')
+parser.add_argument('-fix-fc', dest='fixed_forcing', action='store_true',
+  help='use non-time-dependent forcing instead of method in default case setup (time-dependent)')
+parser.add_argument('-splat-off', dest='turn_off_splat', action='store_true',
+  help='use nonzero spatting terms in default case setup instead of setting them to zero') 
+parser.add_argument('-standard-aterms', dest='standard_aterms', action='store_true',
+  help='use aterms in default case setup instead of keeping them in the derivative')
+parser.add_argument('-smooth-tau', dest='smoothed_tau', action='store_true',
+  help='use formula of tau (for wpxp) in default case setup without smoothed Heavidise function')
+parser.add_argument('-lin-diff', dest='linear_diffusion', action='store_true',
+  help='use nonlinear diffusion in default case setup instead of linear diffusion')
+parser.add_argument('-new-lim', dest='modified_BVF_Ri_limiter', action='store_true',
+  help='use modified limiters on BVF and Ri instead of default case setup')
+parser.add_argument('-new-wp3cl', dest='modified_wp3_clip', action='store_true',
+  help='use modified skewness clippings on wp3 instead of default case setup') 
+parser.add_argument('-godwp3', metavar='name', dest='godunov_wp3',
+  help='use specified Godunov-like scheme instead of central difference (for wp3 equation)')
+parser.add_argument('-godxpyp', metavar='name', dest='godunov_xpyp',
+  help='use specified Godunov-like scheme instead of central difference (for xpyp equation)')
+parser.add_argument('-skip-check', action='store_true',
+  help='skip the pause in the script that allows user to inspect configuration changes')
+parser.add_argument('-warm-init', dest='restart_run', action='store_true',
+  help='do restart run instead of cold initialization using an existing simulation')
+
+# create dictionary of parameters to change (remove None and False vals)
+parameters = vars(parser.parse_args(sys.argv[1:]))
+unset_keys = []
+for key, val in parameters.items():
+  if (val is None or val is False):
+    unset_keys.append(key)
+for key in unset_keys:
+  del parameters[key]
+
+# concatenate all other input namelist files to one file
+line_collections = []
+# "parameter" file
+input_file = open(os.path.join(tunable_dir, 'tunable_parameters.in'), 'r')
+line_collections.append(input_file.readlines())
+input_file.close()
+# "SILHS_PARAMS" file
+input_file = open(os.path.join(tunable_dir, 'silhs_parameters.in'), 'r')
+line_collections.append(input_file.readlines())
+input_file.close()
+# "FLAGS" file
+input_file = open(os.path.join(tunable_dir, 'configurable_model_flags.in'), 'r')
+input_lines = input_file.readlines()
+input_file.close()
+for line in input_lines:
+  if (not line.strip().startswith('!')):
+    ind = line.find('!')
+    if (ind != -1):
+      line = line[0:ind] + '\n'
+    line_collections.append(line)
+    if (line.startswith('tridiag_solve_method')):
+      if ('smoothed_tau' in parameters):
+        if (not any('l_smooth_Heaviside_tau_wpxp' in tmpstr for tmpstr in input_lines)):
+          lnew = 'l_smooth_Heaviside_tau_wpxp = .false.,' + '\n'
+          line_collections.append(lnew)
+          print('append line '+lnew)
+      if ('linear_diffusion' in parameters):
+        if (not any('l_linear_diffusion' in tmpstr for tmpstr in input_lines)):
+          lnew = 'l_linear_diffusion = .false.,' + '\n'
+          line_collections.append(lnew)
+          print('append line '+lnew)
+      if ('modified_BVF_Ri_limiter' in parameters):
+        if (not any('l_use_modify_limiters' in tmpstr for tmpstr in input_lines)):
+          lnew = 'l_use_modify_limiters = .false.,' + '\n'
+          line_collections.append(lnew)
+          print('append line '+lnew)
+      if ('modified_wp3_clip' in parameters):
+        if (not any('l_smooth_Heaviside_wp3_lim' in tmpstr for tmpstr in input_lines)):
+          lnew = 'l_smooth_Heaviside_wp3_lim = .false.,' + '\n'
+          line_collections.append(lnew)
+          print('append line '+lnew)
+# "MOD_MODEL" file
+model_file_name = parameters['case'] + '_model.in'
+input_file = open(os.path.join(case_dir, model_file_name), 'r')
+input_lines = input_file.readlines()
+input_file.close()
+for line in input_lines:
+  if (not line.strip().startswith('!')):
+    ind = line.find('!')
+    if (ind != -1):
+      line = line[0:ind] + '\n'
+    line_collections.append(line)
+    if (line.startswith('runtype')):
+      if (not any('nzmax' in tmpstr for tmpstr in line_collections)):
+        lnew = 'nzmax = 999' + '\n'
+        line_collections.append(lnew)
+        print('append line '+lnew)
+      if ('modified_bc' in parameters):
+        if (not any('l_modify_bc_for_cnvg_test' in tmpstr for tmpstr in input_lines)):
+          lnew = 'l_modify_bc_for_cnvg_test = .false.,' + '\n'
+          line_collections.append(lnew)
+          print('append line '+lnew)
+    elif (line.startswith('rad_scheme')):
+      if (not any('l_calc_thlp2_rad' in tmpstr for tmpstr in input_lines)):
+        lnew = 'l_calc_thlp2_rad = .true.,' + '\n'
+        if (line.split()[2] == '"none",'):
+          lnew = 'l_calc_thlp2_rad = .false.,' + '\n'
+        line_collections.append(lnew)
+        print('append line '+lnew)
+      if (not any('l_rad_above_cloud' in tmpstr for tmpstr in input_lines)):
+        lnew = 'l_rad_above_cloud = .true.,' + '\n'
+        if (line.split()[2] == '"none",'):
+          lnew = 'l_rad_above_cloud = .false.,' + '\n'
+        line_collections.append(lnew)
+        print('append line '+lnew)
+    elif (line.startswith('microphys_scheme')):
+      if (not any('l_var_covar_src' in tmpstr for tmpstr in input_lines)):
+        lnew = 'l_var_covar_src = .true.' + '\n'
+        if (line.split()[2] == '"none"'):
+          lnew = 'l_var_covar_src = .false.' + '\n'
+        line_collections.append(lnew)
+        print('append line '+lnew)
+      if (not any('l_cloud_sed' in tmpstr for tmpstr in input_lines)):
+        lnew = 'l_cloud_sed = .true.' + '\n'
+        if (line.split()[2] == '"none"'):
+          lnew = 'l_cloud_sed = .false.' + '\n'
+        line_collections.append(lnew)
+        print('append line '+lnew)
+# "stats" file
+input_file = open(os.path.join(stats_dir,'standard_stats.in'), 'r')
+line_collections.append(input_file.readlines())
+input_file.close()
+# write out to namelist file
+out_file_name = parameters['case'] + '_default.in' 
+namelist_file = open(out_file_name, 'w')
+for line_collection in line_collections:
+  for line in line_collection:
+    ind = line.find('!')
+    if (ind != -1):
+      line = line[0:ind] + '\n'
+    namelist_file.write(line)
+namelist_file.close()
+
+# read the default namelist setup and modify it for convergence test 
+model_file      = open(out_file_name, 'r')
+model_config    = model_file.readlines()
+model_file.close()
+# create a file to save the modified namelist 
+# use concatenated model file name from specified parameters
+# unless user specified their own name
+if ('output_name' not in parameters):
+  model_file_name = model_file_name.replace('_model.in', '')
+  for parameter in parameters:
+    if (parameter == 'case' or parameter == 'skip_check'):
+      continue
+    if (isinstance(parameters[parameter], bool) and parameters[parameter]):
+      model_file_name += '_' + parameter.replace('_','-')
+    elif (parameters[parameter]):
+      model_file_name += '_' + parameter + '-' + parameters[parameter]
+else:
+  model_file_name = model_file_name.replace('_model.in', '')
+  for parameter in parameters:
+    if (parameter != 'dt' and parameter != 'dz' and parameter != 'refine' and parameter != 'godunov_wp3' and 
+        parameter != 'godunov_xpyp' and parameter != 'output_name'):
+      continue
+    if (isinstance(parameters[parameter], bool) and parameters[parameter]):
+      model_file_name += '_' + parameter.replace('_','-')
+    elif (parameters[parameter]):
+      model_file_name += '_' + parameter + '-' + parameters[parameter]
+
+# create modified configuration model file
+model_file_name += '.in'
+model_file = open(model_file_name, 'w')
+
+# create dictionary of configuration strings from parameters
+config_strings = {}
+config_strings['fname_prefix'] = '"' + model_file_name.replace('.in','') + '"'
+
+# set output to netcdf unless user has specified something else
+if ('default_format' not in parameters):
+  config_strings['stats_fmt'] = '"netcdf"'
+
+# set microphysics to "none" unless user has specified something else
+if ('turn_off_microphysics' in parameters):
+  config_strings['microphys_scheme'] = '"none"'
+  config_strings['l_var_covar_src'] = '.false.'
+  config_strings['l_cloud_sed'] = '.false.'
+
+# turn off radiation unless user has specified something else
+if ('turn_off_radiation' in parameters):
+  config_strings['rad_scheme']        = '"none",'
+  config_strings['l_calc_thlp2_rad']  = '.false.,'
+  config_strings['l_rad_above_cloud'] = '.false.,'
+
+# set l_standard_term_ta to true unless user has specified something else
+if ('standard_aterms' in parameters):
+  config_strings['l_standard_term_ta'] = '.true.'
+
+# fix flux computation height unless user has specified otherwise
+if ('modified_ic' in parameters):
+  #config_strings['l_modify_ic_with_cubic_int'] = '.true.,'
+  if ('dycoms2_rf02' in parameters['case']):
+    case_name = 'dycoms2_rf02'
+  else: 
+    case_name = parameters['case'] 
+  if ('dz' in parameters):
+    case_dz = 1.0
+    case_ref  = -9999
+  elif ('refine' in parameters):
+    case_dz  = -9999.0
+    case_ref = 7 
+  else:
+    sys.exit('must specify grid spacing or refinement level info.....') 
+  modify_ic_profile(clubb_dir, case_dir, grid_dir, case_name, case_dz, case_ref)
+
+# used revised boundary condition if user has specified 
+if ('modified_bc' in parameters):
+  config_strings['l_modify_bc_for_cnvg_test'] = '.true.,'
+
+#set time-dependent forcing to false
+if ('fixed_forcing' in parameters):
+  config_strings['l_ignore_forcings'] = '.true.'
+
+# set no splatting unless user has specified something else
+if ('turn_off_splat' in parameters):
+  config_strings['C_wp2_splat'] = '0.0'
+
+# set l_smooth_Heaviside_tau_wpxp to true unless unless user has specified otherwise
+if ('smoothed_tau' in parameters):
+  config_strings['l_smooth_Heaviside_tau_wpxp'] = '.true.,'
+
+# use linear diffusion instead of nonlinear diffusion unless user has specified otherwise
+if ('linear_diffusion' in parameters):
+  config_strings['l_linear_diffusion'] = '.true.,'
+  #specific setup for coefficients in linear diffusion 
+  #(used in clubb convergence paper) 
+  config_strings['c_K1'] = '0.000000'
+  config_strings['c_K2'] = '0.000000'
+  config_strings['c_K6'] = '0.000000'
+  config_strings['c_K8'] = '0.000000'
+  config_strings['c_K9'] = '0.000000'
+  config_strings['nu1']  = '21.00000'
+  config_strings['nu2']  = '1.000000'
+  config_strings['nu6']  = '5.000000'
+  config_strings['nu8']  = '36.00000'
+  config_strings['nu9']  = '10.00000'
+  #slightly increase the dissipation term for wpxp 
+  config_strings['C_invrs_tau_N2_wpxp'] = '0.02'
+
+# use modified setup for limiters on BVF and Ri unless user has specified otherwise
+if ('modified_BVF_Ri_limiter' in parameters):
+  config_strings['l_use_modify_limiters'] = '.true.,'
+
+if ('modified_wp3_clip' in parameters): 
+  config_strings['l_smooth_Heaviside_wp3_lim'] = '.true.' 
+
+# set restart run information
+if ('restart_run' in parameters):
+  config_strings['l_restart'] = '.true.'
+  config_strings['restart_path'] = '"'+ os.path.join(res_dir,parameters['case']) +'"'
+  if ('tinitial' in parameters):
+    config_strings['time_restart'] = str(float(parameters['tinitial']) + 3600.0)
+  else: 
+    config_strings['time_restart'] = '3600.0'
+
+# match dt_output to max of dt or 60s unless it is specifically provided
+if ('dt' in parameters):
+  config_strings['dt_main'] = parameters['dt']
+  config_strings['dt_rad'] = parameters['dt']
+  if ('dt_output' not in parameters):
+    parameters['dt_output'] = str(max(float(parameters['dt']), 600.0))
+if ('dt_output' in parameters):
+  config_strings['stats_tsamp'] = parameters['dt_output']
+  config_strings['stats_tout'] = parameters['dt_output']
+
+# if dz specified, set other associated options
+if ('dz' in parameters):
+  config_strings['deltaz'] = parameters['dz']
+  config_strings['grid_type'] = '1'
+  config_strings['zt_grid_fname'] = "''"
+
+# if refinement specified, create grid file and set appropriate file name
+if ('refine' in parameters):
+  # read namelist file to obtain model height in case setup 
+  config_strings['grid_type'] = '2'
+  tmp_file_name = parameters['case'] + '_model.in' 
+  input_file = open(os.path.join(case_dir, tmp_file_name), 'r')
+  input_lines = input_file.readlines()
+  input_file.close()
+  height = -999.0 
+  for line in input_lines:
+    if ('zm_top' in line):
+      height = float(line.split()[2])
+  if (height == -999.0): 
+    sys.exit('Model height are not prescribed in namelist, space refinement failed...') 
+  #generate refined grid 
+  refine = int(parameters['refine'])
+  grid128 = np.loadtxt(os.path.join(grid_dir,'deep_convection_128lev_27km_zt_grid.grd'))
+  ind = np.where(grid128 > height)[0][0]
+  grid128 = grid128[:ind]
+  grid128[0] = 0.0
+  size = (len(grid128)-1)*2**refine + 1
+  grid = np.empty((size))
+  coarse_ind = np.arange(len(grid128))
+  refine_ind = np.arange(0,size,2**refine)
+  grid[refine_ind] = grid128[coarse_ind]
+  for level in range(refine):
+    coarse_ind = np.arange(0, size, 2**(refine-level))
+    refine_ind = coarse_ind[:-1] + 2**(refine-level-1)
+    grid[refine_ind] = 0.5*(grid[coarse_ind[1:]] + grid[coarse_ind[:-1]])
+  grid[0] = -grid[1]
+  #specify the levels of refined grid in namelist file 
+  config_strings['nzmax'] = str(len(grid))
+  #save grid file and specify refined grid in namelist file 
+  grid_filename = '{}_convection_{}lev_27km_zt_grid.grd'.format(parameters['case'],config_strings['nzmax'])
+  np.savetxt(grid_filename, grid)
+  config_strings['zt_grid_fname'] = f"'{grid_filename}'"
+
+# set initial time if specified
+if ('tinitial'in parameters):
+  config_strings['time_initial'] = parameters['tinitial']
+# set final time if specified
+if ('tfinal' in parameters):
+  config_strings['time_final'] = parameters['tfinal']
+
+# set Godunov upwinding, if specified
+if ('godunov_wp3' in parameters):
+  config_strings['l_godunov_upwind_wp3_ta'] = '.true.'
+
+if ('godunov_xpyp' in parameters):
+  config_strings['l_godunov_upwind_xpyp_ta'] = '.true.'
+  config_strings['l_upwind_xpyp_ta'] = '.false.'
+
+# warn about Tsfc parameter
+if ('Tsfc' in parameters):
+  print("WARNING: Specifying Tsfc doesn't change model parammeters...")
+  print("         this needs to be done in " + parameters['case'] + "_sounding.in")
+  input("Press Enter to acknowledge")
+
+modified_lines = []
+for line in model_config:
+  modified = False
+  # Apply changes in model configurations 
+  if (not line.strip().startswith('!')):
+    for key, val in config_strings.items():
+      # adjust values
+      if (line.startswith(key)):
+        if (line.split()[0] == key): 
+          default_value = line.split()[2]
+          line = line.replace(default_value, val)
+          modified = True
+          print(f'Setting {key} to {val}')
+          print(line)
+
+  # write line to model configuration (and record if modified)
+  if (not line.strip().startswith('!')):
+    model_file.write(line)
+  if (modified):
+    modified_lines.append(line)
+
+model_file.close()
+
+print('Wrote ' + model_file_name + ' file with the following modified lines:\n')
+for line in modified_lines:
+  print(line),
+
+# execute CLUBB
+shutil.copy(model_file_name, 'clubb.in')
+if ('skip_check' not in parameters):
+  input('Press Enter to run CLUBB...')
+os.system(os.path.join(bin_dir, 'clubb_standalone'))

--- a/run_scripts/convergence_run/convergence_function.py
+++ b/run_scripts/convergence_run/convergence_function.py
@@ -1,0 +1,174 @@
+import argparse
+import numpy as np
+import os
+import sys
+import shutil
+
+def modify_ic_profile(clubb_dir, case_dir, grid_dir, case, dz, refine): 
+
+  print('construct initial condition file for ' + case)
+
+  if (case != "dycoms2_rf02"): 
+    # read the initial sounding profile and increase height levels 
+    # note: the data in new levels are all set to missing values as 
+    #       we do not attempt to change the original sounding profiles 
+    #       the purpose is to have denser height levels so that the cubic 
+    #       spline interpolation does not generate strange profiles 
+    input_file_name = case + '_sounding.in'
+    input_file  = open(os.path.join(case_dir, input_file_name), 'r')
+    input_lines = input_file.readlines()
+    input_file.close()
+    line_collections = []
+    line_data = []
+    for line in input_lines:
+      if (line.strip().startswith('!')):
+        line_collections.append(line)
+      elif (line.strip().startswith('z[m]')):
+        line_collections.append(line)
+        refline = line
+      else: 
+        line_data.append(line)
+    zdat = []
+    znew = []
+    zmin = 0 
+    zmax = 0
+    for line in line_data: 
+      zdat.append(float(line.split()[0]))
+      if (float(line.split()[0]) < zmin): 
+        zmin = float(line.split()[0])
+      if (float(line.split()[0]) > zmax):
+        zmax = float(line.split()[0])
+    for val in np.arange(zmin,zmax,100):
+      znew.append(val)
+    zlev = znew + list(set(zdat)- set(znew))
+    zlev.sort()
+    nlev = len(zlev)
+    for i in np.arange(len(zlev)):
+      line = refline
+      for item in refline.split():
+        if (item == "z[m]"):
+          line = line.replace(item, str("{:.1f}".format(zlev[i])))
+        else: 
+          line = line.replace(item, '-999.9')
+      for j in np.arange(len(zdat)): 
+        if (zdat[j] == zlev[i]):
+          line = line_data[j]
+      line_collections.append(line)
+
+    out_file_name = case + '_sounding.in'
+    output_file = open(os.path.join(case_dir, out_file_name), 'w')
+    for line in line_collections:
+      output_file.write(line)
+    output_file.close()
+
+  else: # case == "dycoms2_rf02"
+    # read namelist file to obtain model height in case setup 
+    model_file_name = case + '_nd_model.in'
+    input_file = open(os.path.join(case_dir, model_file_name), 'r')
+    input_lines = input_file.readlines()
+    input_file.close()
+    for line in input_lines:
+      if ('zm_top' in line):
+        height =  float(line.split()[2])
+        htop   = height + 150.0 
+      if ('zm_init' in line):
+        hgtlow =  float(line.split()[2])
+
+    # if refinement specified, create grid file and set appropriate file name
+    if (refine != -9999):
+      #for stretched grid 
+      gridtmp = np.loadtxt(os.path.join(grid_dir,'deep_convection_128lev_27km_zt_grid.grd'))
+      grid128 = 0.5*(gridtmp[0:len(gridtmp)-2] + gridtmp[1:len(gridtmp)-1])
+      ind = np.where(grid128 > htop)[0][0]
+      grid128 = grid128[:ind]
+      grid128[0] = 0.0
+      nlev = (len(grid128)-1)*2**refine + 1
+      grid = np.empty((nlev))
+      coarse_ind = np.arange(len(grid128))
+      refine_ind = np.arange(0,nlev,2**refine)
+      grid[refine_ind] = grid128[coarse_ind]
+      for level in range(refine):
+        coarse_ind = np.arange(0, nlev, 2**(refine-level))
+        refine_ind = coarse_ind[:-1] + 2**(refine-level-1)
+        grid[refine_ind] = 0.5*(grid[coarse_ind[1:]] + grid[coarse_ind[:-1]])
+    elif (dz != -9999): 
+      # for grid with fixed spacing  
+      grid = np.arange(hgtlow, htop, dz, dtype=float)
+      nlev = len(grid)
+    else:  
+      sys.exit('No refinement parameter specified, no need to construct the profile')
+   
+    #construct initial condition profile (Wyant, et al. 2007, eq 1--4) 
+    #rtm and thlm profile 
+    zthres   = 795.0
+    g_per_kg = 1000.0
+    thlm = 295.0 + (np.sign(grid - zthres)) * (np.abs(grid - zthres)) ** (1.0 / 3.0)
+    rtm = (5.0 - 3.0 * (1.0 - np.exp((zthres - grid)/500.0))) / g_per_kg
+    for i in np.arange(nlev):
+      if (grid[i] < zthres):
+        rtm[i] = 9.45/g_per_kg 
+        thlm[i] = 288.3
+    #um and vm profile 
+    um = 3.0 + (4.3*grid/1000.0)
+    vm = -9.0 + (5.6*grid/1000.0)
+    ug = um
+    vg = vm
+    #wm profile 
+    z0 = [0, height, htop]
+    w0 = [0.,-0.006, -0.006]
+    wm = np.interp(grid, z0, w0)
+    #apply smoothing on the profiles of thlm and rtm 
+    #smoothed heaviside function with dzt = 30 m 
+    dzt   = 30
+    thlm2 = 295.0 + (dzt)**(1.0/3.0)
+    thlm1 = 288.3
+    rtm2  = (5.0 - 3.0 * (1.0 - np.exp(-dzt/500.0))) / g_per_kg
+    rtm1  = 9.45/g_per_kg
+    frac  = (grid - zthres) / dzt
+    for i in np.arange(nlev):
+     if( frac[i] >= -1.0 and frac[i] <= 1.0 ):
+        H0 = 0.5*(1.0+frac[i] + (1.0/np.pi)*np.sin(np.pi*frac[i]))
+        thlm[i] = thlm1 + H0*(thlm2 - thlm1)
+        rtm[i]  = rtm1  + H0*(rtm2 - rtm1)
+  
+    #write out the sounding profile 
+    input_file_name = case + '_sounding.in'
+    input_file = open(os.path.join(case_dir, input_file_name), 'r')
+    input_lines = input_file.readlines()
+    input_file.close()
+    line_collections = []
+    for line in input_lines:
+      if (line.strip().startswith('!')):
+        line_collections.append(line)
+      if (line.strip().startswith('z[m]')):
+        line_collections.append(line)
+        refline = line
+    
+    for i in np.arange(nlev):
+      line = refline 
+      for item in refline.split():
+        if(item == "z[m]"): 
+           line = line.replace(item, str("{:.3f}".format(grid[i])))
+        if(item == "thlm[K]"):
+           line = line.replace(item, str("{:.5f}".format(thlm[i])))
+        if(item == "rt[kg\\kg]"):
+           line = line.replace(item, str("{:.5f}".format(rtm[i])))
+        if(item == "u[m\\s]"):
+           line = line.replace(item, str("{:.5f}".format(um[i])))
+        if(item == "v[m\\s]"):
+           line = line.replace(item, str("{:.5f}".format(vm[i])))
+        if(item == "w[m\\s]"):
+           line = line.replace(item, str("{:.6f}".format(wm[i])))     
+        if(item == "ug[m\\s]"):
+           line = line.replace(item, str("{:.5f}".format(ug[i])))
+        if(item == "vg[m\\s]"):
+           line = line.replace(item, str("{:.5f}".format(vg[i])))
+      line_collections.append(line)
+     
+    out_file_name = case + '_sounding.in' 
+    output_file = open(os.path.join(case_dir, out_file_name), 'w')
+    for line in line_collections:
+      output_file.write(line)
+    output_file.close()
+  
+  return 

--- a/run_scripts/convergence_run/plot_l2_convergence.py
+++ b/run_scripts/convergence_run/plot_l2_convergence.py
@@ -1,0 +1,121 @@
+import numpy as np
+from cycler import cycler
+from netCDF4 import Dataset
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import matplotlib.gridspec as gridspec
+from matplotlib.font_manager import FontProperties
+from matplotlib.ticker import (MultipleLocator, AutoMinorLocator)
+from matplotlib import rc
+import seaborn as sns
+
+case         = "CASE_NAME"
+expnam       = "EXP_NAME"
+#refinment factor and time step sizes 
+#refineLevels = [0, 1, 2, 3, 4, 5, 7]
+refineLevels = [REFINE_LEVELS]
+#coresponded time steps
+#dtValues     = [4, 2, 1, 0.5, 0.25, 0.125, 0.03125]
+dtValues     = [DTIME_VALUES]
+#corresponded plotting time index for 1-h, 2-h, 3-h, 4-h, 5-h, 6-h 
+#tIndices     = [5, 11, 17, 23, 29, 35]
+tIndices     = [DTIME_INDEX]
+
+Datadir      = '../output'
+Filename     = Datadir + '/' + case + '_dt-{}_refine-{}_output_name-'+expnam+'_{}.nc'
+Figstr       = case+'_l2_cnvg_'+expnam
+tstart       = 0
+
+color_cycle  = ['#377eb8', '#ff7f00', '#4daf4a',
+                '#f781bf', '#a65628', '#984ea3',
+                '#999999', '#e41a1c', '#dede00',
+                '#76b7b2', '#121211', '#FF00FF']
+rc('font',**{'family':'serif','serif':['Times New Roman'],'style':'normal','weight':'normal'})
+#rc('text',usetex=True)
+font_size = 20
+
+##variable names and output levels 
+vnmList      = ['wp3','wp2','rtm','thlm','rtp2','thlp2','rtpthlp', 'um', 'vm', 'upwp', 'vpwp', 'wprtp', 'wpthlp', 'up2', 'vp2']
+sufList      = [ 'zt', 'zm', 'zt',  'zt',  'zm',   'zm',     'zm', 'zt', 'zt',   'zm',   'zm',    'zm',     'zm',  'zm',  'zm']
+
+for iv in range(len(vnmList)-1):
+
+  varName = vnmList[iv]
+  suffix  = sufList[iv]
+
+  if (suffix == 'zm'):
+    def startIndex(n):
+      return 0
+  else:
+    def startIndex(n):
+      return 2**n
+
+  dataList = []
+  for i,refineLevel in enumerate(refineLevels):
+    dt = dtValues[i]
+    dataList.append(Dataset(Filename.format(dt, refineLevel, suffix)))
+
+  n = refineLevels[-1] - refineLevels[0]
+  varRef = dataList[-1][varName][:,range(startIndex(n),len(dataList[-1]['altitude'][:]),2**n),0,0]
+
+  varList = []
+  for n in range(len(dataList)-1):
+    data = dataList[n]
+    varList.append(data[varName][:,range(startIndex(n),len(data['altitude'][:]),2**n),0,0])
+
+  z = dataList[0]['altitude'][1:]
+  f, ax = plt.subplots(figsize=(8.0,6.6),nrows=1,ncols=1)
+  ax.set_prop_cycle('color', color_cycle)
+
+  for tIndex in tIndices:
+    rmsList = []
+    dzList = []
+    for n,var in enumerate(varList):
+      dzList.append(1.0/2**n)
+      rms = np.sqrt(np.mean((var[tIndex,:]-varRef[tIndex,:])**2))
+      rmsList.append(rms)
+
+    # These are the colors that will be used in the plot
+    order = np.log(rmsList[-2]/rmsList[-1])/np.log(2)
+    ylog = np.log10(rmsList)
+    xlog = np.log10(dzList)
+    ax.plot(xlog,ylog, '-o', linewidth=2.0, markersize=8.0,
+               markeredgecolor='black', markeredgewidth=0.5,
+               label='{:.0f}{} ({:.2f})'.format(
+                   (dataList[0]['time'][tIndex])/3600.0,'h',order))
+
+  ax.set_title('Convergence of {} ( {} )'.format(varName,case.upper()),fontsize=font_size*1.1,loc='center',x=0.5,y=1.01)
+  ax.set_ylabel('{}'.format('log10 (RMSE)'), fontsize=font_size)
+  #normalized grid spacing(z^*)
+  ax.set_xlabel('{}'.format('log10 (Normalized grid spacing)'), fontsize=font_size)
+  #set legend 
+  leg = ax.legend(loc='best',fontsize = font_size*0.94,labelspacing=0.24,markerscale=0.8,
+            handlelength=1.0,handletextpad=0.5,handleheight=0.8) 
+  # set the linewidth of each legend object
+  for legobj in leg.legendHandles:
+      legobj.set_linewidth(2.0)
+
+  for axis in ['top','bottom','left','right']:
+      ax.spines[axis].set_linewidth(0.6)
+ 
+  ax.xaxis.set_minor_locator(MultipleLocator(0.25))
+  ax.xaxis.set_major_locator(MultipleLocator(0.5))
+  ax.yaxis.set_minor_locator(MultipleLocator(0.25))
+  ax.yaxis.set_major_locator(MultipleLocator(0.5))
+
+  ax.tick_params(which='both',  direction='in', pad=6, 
+                 width=0.5, labelsize=font_size*0.95, right=True, top=True)
+  ax.tick_params(which='major', length=4.5)
+  ax.tick_params(which='minor', length=3.0) #, color='b')
+  ax.set_xlim(-2.0, 1.0)
+  ax.set_aspect('equal')
+
+  #add reference line with slope 1 
+  xref = ax.get_xlim()
+  yrex = ax.get_ylim()
+  yref = xref + np.mean(yrex) - np.mean(xref)
+  ax.plot(xref,yref,dashes=[6, 2], linewidth=1.2, color='black')
+
+  #plt.tight_layout(pad=1.5)
+  plt.savefig('figure/convergence_{}_{}.png'.format(Figstr,varName))
+

--- a/run_scripts/convergence_run/run_cnvg_test_multi_cases.csh
+++ b/run_scripts/convergence_run/run_cnvg_test_multi_cases.csh
@@ -1,0 +1,276 @@
+#!/bin/csh
+#SBATCH -A esmd 
+#SBATCH -p short 
+#SBATCH -N 1     
+#SBATCH -t 2:00:00 
+#SBATCH -J convergence_%j 
+#SBATCH -o convergence_%j.out 
+#SBATCH -e convergence_%j.err 
+
+# Flag to run model compiling section 
+set compile_model  = 0  # False: 0, True: 1
+
+# Flag to run simulation section 
+set run_model      = 1  # False: 0, True: 1
+
+# Flag to run diagnose section. note: user needs to proprely setup 
+# the environment for python in order to generate diagnostic figures 
+set run_diagnostic = 1  # False: 0, True: 1
+
+#user-specified code location, experiment name and model run directory 
+set topdir = "/compyfs/zhan391/code/clubb_standalone_fnl/clubb_release-push"
+set expnam = "revbc"
+set wkdir  = "${topdir}/cnvg_${expnam}"
+set outdir = "${topdir}/output"
+
+if ( ! -d ${wkdir} ) then 
+ mkdir -p ${wkdir}
+endif 
+
+if ( ! -d ${outdir} ) then
+ mkdir -p ${outdir}
+endif
+
+#user-specified flags for configurations 
+#options: 
+# -rad-off: Turning off radiation scheme instead of using default case setup 
+# -micro-off: Turning off microphysics scheme instead of using default case setup
+# -fix-fc: using default setup for forcing (e.g. large-scale dynamics) which can be 
+#              time dependent instead of setting the time-dependent forcing to .false. 
+# -new-bc: using modified boundary condition in which surface fluxes are computed at 
+#          a fixed 25m model height, instead of the method in default setup (surface fluxes 
+#          depend on grid spacing when vertical grid is refined) 
+# -new-ic: using modified initial conditions instead of the method in default setup 
+#          (linear interpolation on sparse sound profile) 
+# -standard-aterms: using standard turbulent advection terms derived from continuous equation 
+#                   instead of method in default model setup ( i.e. pull "a coef." outside 
+#                   of the vertical derivative) 
+# -smooth-tau: using new formulations with smoothed Heaviside function for eddy dissipation time 
+#              scale of turbulent fluxes (tau_wpxp) instead of the default method (employs a 
+#              non-smoothed step function that can introduce discontinuities in model equations)
+# -lin-diff: using the default nonlinear numerical diffusion instead of linear numberical 
+#             diffusion as discussed in clubb convergence paper               
+# -splat-off: using default setup for wp2 splatting terms (non-zero and determined by C_wp2_splat 
+#             parameter) instead of setting the term to zero (i.e. set C_wp2_splat = 0.0) 
+# -new-lim: using the default setup for limiters on Brunt–Väisälä frequency and Richardson 
+#           number instead of modified limiters as discussed in clubb convergence paper 
+# -new-wp3cl: using the new formulation with smoothed Heaviside function for skewness clippings 
+#             on wp3 instead of the method in default model setup 
+# -godwp3: if specified, using Godunov upwinding discretization for turbulent advection
+#          terms in wp3 equation instead of using cenctered-differencing scheme in 
+#          default case setup in CLUBB 
+# -godxpyp: if specified, using Godunov upwinding discretization for turbulent advection
+#           terms in xpyp equations instead of using cenctered-differencing scheme in 
+#           default case setup in CLUBB 
+#Note: -godwp3 and -godxpyp are not discussed in clubb convergence paper 
+
+# For convergence test disucssed in clubb convergence paper (Zhang_Vogl_Larson et. al. : 2023, JAMES), first-order 
+# convergence can be obtained with the combined changes of: 
+# a. turn off radiation and mincrophysics parameterization   (-rad-off -micro-off) 
+# b. turn off C_wp2 splatting terms (i.e. C_wp2_splat = 0.0) (-splat-off) 
+# c. use standard turbulent advection term (i.e. a coef. inside vertical derivative) (-standard-aterms)
+# d. use modified initial condition (with non-grid-dependent sounding profile + cubic-spline interpolation) (-new-ic)
+# e. use modified boundary condition (non time-dependent forcing + compute surface fluxes at fixed model height) (-new-bc -fix-fc)
+# f. use modified limiters on the Brunt–Väisälä frequency and Richardson number (-new-lim)
+# g. smooth the eddy dissipation time scele for wpxp (with smoothed heaviside function) (-smooth-tau)
+# h. use the linear numerical diffusion instead of nonlinear numberical diffusion (-lin-diff)
+# i. use the smooth Heaviside function to construct the limiters for skewness clippings on wp3 (-new-wp3cl)
+
+# For test simulations with default configuration (no changes)
+# set config_flags = ""
+# For test simulations with baseline configuration (turn off mincrophysics + radiation + splatting, use standard ta)
+# set config_flags = "-rad-off -micro-off -standard-aterms -splat-off"
+# For test simulations with all changes from (Zhang_Vogl_Larson et. al., 2023, JAMES).
+# set config_flags = "-rad-off -micro-off -standard-aterms -splat-off -new-ic -new-bc -new-lim -smooth-tau -lin-diff -new-wp3cl"
+
+set config_flags = "-new-bc"
+
+#set config_flags = "-rad-off -micro-off -standard-aterms -splat-off"
+set dt_output    = 60   # output frequency in seconds, default setup for convergence simulation
+                        # is 600s (maximum time step size used for simulation)
+
+#user-specified code and simulation run directory
+#the default is the same as simulation setup in 
+#clubb convergence paper (Zhang et. al., 2023, JAMES)
+#name, start and end time for test case  in clubb-scm, 
+set case   = ( bomex  rico   dycoms2_rf02_nd  wangara )  
+set t0     = ( 0      0      0                82800 ) 
+set tf     = ( 21600  21600  21600            104400 ) 
+set ncase  = $#case
+
+#user-specified time-step and grid-spacing refinements for convergence test  
+#the default is the same as simulation setup in clubb convergence paper 
+#(Zhang_Vogl_Larson et. al., 2023, JAMES)
+#set refine_levels = (0  1  2    3    4     5      6       7) 
+#set time_steps    = (4  2  1  0.5 0.25 0.125 0.0625 0.03125) 
+#set nrefs         = $#refine_levels
+
+set refine_levels = (  0   0   0  0  0  1  2    3      5 ) 
+set time_steps    = ( 60  30  15  8  4  2  1  0.5  0.125 ) 
+set nrefs         = $#refine_levels
+
+#compile model
+if ( $compile_model > 0 )  then 
+
+  cd $topdir/compile  
+
+  sed -i "s/linux_x86_64_gfortran.bash/linux_x86_64_ifort_compy.bash/g" compile.bash
+  ./clean_all.bash 
+  ./compile.bash 
+
+  #make sure the flag for modified ic is turned on 
+  set cind = `echo $config_flags | awk '{print index($0,"-new-ic")}'`      
+  set object = `echo $config_flags | awk '{print substr($0,'$cind',7)}'` 
+  if( $object == "-new-ic") then
+     sed -i "s/l_modify_ic_with_cubic_int = .false./l_modify_ic_with_cubic_int = .true./g" src/sounding.F90
+  endif
+
+  if ( -f  "${topdir}/bin/clubb_standalone" ) then 
+    echo "Model complie succeed, continue ...."
+  else 
+    echo "Model compile failed, aborting  ...."
+    exit 
+  endif  
+
+endif 
+
+#run simulations#
+if ( ${run_model} > 0 ) then 
+  echo "convergence simulation start"
+  date
+  echo
+
+  if ( ! -d "${outdir}" ) then 
+     mkdir -p ${outdir}
+  endif 
+
+  cd ${wkdir}
+
+  set i = 1
+  while ( $i <= $ncase )
+
+    set casnam = $case[$i]
+    set tstart = $t0[$i]
+    set tend   = $tf[$i]
+    echo "Running simulaitons for $casnam : tstart = $tstart, tend = $tend" 
+
+    set run_script = ${expnam}_${casnam}_cnvg.bash
+#generate shell scripts to run simulations on-the-fly 
+cat << EOB >!  ${run_script} 
+#!/bin/bash
+date  
+echo
+EOB
+    set k = 1
+    while ( $k <= $nrefs )
+      set jobid  = `printf "%02d" $k`
+      set config = "-dt $time_steps[$k] -ref $refine_levels[$k] -ti ${tstart} -tf ${tend} -dto ${dt_output}" 
+      set strs0  = 'time python3 '"${topdir}"'/run_scripts/convergence_run/convergence_config.py $1 -output-name $2'
+      if( $k < $nrefs) then 
+        set strs1  = '-skip-check ${@:3} > ${1}_${2}_${SLURM_JOBID}-'"${jobid}"'.log 2>&1 &'
+      else
+        set strs1  = '-skip-check ${@:3} > ${1}_${2}_${SLURM_JOBID}-'"${jobid}"'.log 2>&1 '
+      endif
+      echo ""  >> ${run_script}
+      echo "${strs0}  ${config} ${config_flags}  ${strs1}" >> ${run_script}
+      echo "sleep 20" >> ${run_script}
+      @ k++
+    end
+    
+cat << EOB >>!  ${run_script} 
+date 
+echo
+EOB
+    #run simulation 
+    bash ${run_script}  $casnam  ${expnam} & 
+
+    sleep 5m 
+
+   @ i++  
+  end 
+
+  wait
+
+  if ( ! -d "${wkdir}/log_file" ) then 
+    mkdir -p ${wkdir}/log_file
+  endif
+  mv *${expnam}*.log ${wkdir}/log_file/
+
+  if ( ! -d "${wkdir}/config_file" ) then
+    mkdir -p ${wkdir}/config_file
+  endif
+  mv *${expnam}*.in  ${wkdir}/config_file/
+
+  date
+  echo
+  echo "convergence simulation done"
+endif 
+
+#generate convergence figures#
+if ( $run_diagnostic > 0 ) then 
+  echo "post-processing start"
+  date
+  echo
+ 
+  #load python environment (user-specified)
+  # module load python
+  module load anaconda3/2019.03 
+  source /share/apps/anaconda3/2019.03/etc/profile.d/conda.csh
+  conda activate e3sm_analysis 
+
+  set i = 1
+  while ( $i <= $ncase )
+
+    if ( ! -d "${wkdir}/figure" ) then
+      mkdir ${wkdir}/figure
+    endif
+
+    set casnam = $case[$i]
+
+    cd ${wkdir}
+
+    cp ${topdir}/run_scripts/convergence_run/plot_l2_convergence.py ${casnam}_fig.py
+    set j = 1
+    while ( $j <= $nrefs ) 
+      if ( $j == 1) then 
+        set reflevs = "$refine_levels[$j]"
+        set dtsteps = "$time_steps[$j]"
+      else 
+        set reflevs = "$reflevs,$refine_levels[$j]"
+        set dtsteps = "$dtsteps,$time_steps[$j]"
+      endif 
+     @ j++ 
+    end 
+    #1-h, 2-h ... 6-h index in output 
+    foreach hour ( 1 2 3 4 5 6 ) 
+      @ indx = $hour * 3600 / $dt_output - 1
+      if ( $hour == 1 ) then 
+        set tpindex = "$indx"
+      else  
+        set tpindex = "$tpindex,$indx"
+      endif 
+    end  
+    #echo $reflevs 
+    #echo $dtsteps
+    #echo $tpindex
+    sed -i "s/CASE_NAME/${casnam}/g"         ${casnam}_fig.py
+    sed -i "s/EXP_NAME/${expnam}/g"          ${casnam}_fig.py
+    sed -i "s/REFINE_LEVELS/${reflevs}/g"    ${casnam}_fig.py
+    sed -i "s/DTIME_VALUES/${dtsteps}/g"     ${casnam}_fig.py
+    sed -i "s/DTIME_INDEX/${tpindex}/g"      ${casnam}_fig.py
+
+    python ${casnam}_fig.py
+
+    rm -rvf  ${casnam}_cnvg.bash
+    rm -rvf  ${casnam}_fig.py
+
+    @ i++ 
+  end 
+
+  date
+  echo
+  echo "post-processing done"
+endif 
+
+exit 
+

--- a/src/CLUBB_core/clubb_api_module.F90
+++ b/src/CLUBB_core/clubb_api_module.F90
@@ -4528,6 +4528,7 @@ contains
                                                  l_use_tke_in_wp3_pr_turb_term, & ! Out
                                                  l_use_tke_in_wp2_wp3_K_dfsn, & ! Out
                                                  l_smooth_Heaviside_tau_wpxp, & ! Out
+                                                 l_modify_bc_for_cnvg_test, & ! Out 
                                                  l_enable_relaxed_clipping, & ! Out
                                                  l_linearize_pbl_winds, & ! Out
                                                  l_mono_flux_lim_thlm, & ! Out
@@ -4657,6 +4658,8 @@ contains
       l_smooth_Heaviside_tau_wpxp,  & ! Use smoothed Heaviside 'Peskin' function
                                       ! in the calculation of H_invrs_tau_wpxp_N2
                                       ! in src/CLUBB_core/mixing_length.F90
+      l_modify_bc_for_cnvg_test,    & ! Flag to activate modifications on boundary condition for 
+                                      ! convergence test (surface fluxes computed at fixed 25m height) 
       l_enable_relaxed_clipping,    & ! Flag to relax clipping on wpxp
                                       ! in xm_wpxp_clipping_and_stats
       l_linearize_pbl_winds,        & ! Code to linearize PBL winds
@@ -4716,6 +4719,7 @@ contains
                                          l_use_tke_in_wp3_pr_turb_term, & ! Out
                                          l_use_tke_in_wp2_wp3_K_dfsn, & ! Out
                                          l_smooth_Heaviside_tau_wpxp, & ! Out
+                                         l_modify_bc_for_cnvg_test, & ! Out 
                                          l_enable_relaxed_clipping, & ! Out
                                          l_linearize_pbl_winds, & ! Out
                                          l_mono_flux_lim_thlm, & ! Out

--- a/src/CLUBB_core/model_flags.F90
+++ b/src/CLUBB_core/model_flags.F90
@@ -397,6 +397,7 @@ module model_flags
                                              l_use_tke_in_wp3_pr_turb_term, &
                                              l_use_tke_in_wp2_wp3_K_dfsn, &
                                              l_smooth_Heaviside_tau_wpxp, &
+                                             l_modify_bc_for_cnvg_test, & 
                                              l_enable_relaxed_clipping, &
                                              l_linearize_pbl_winds, &
                                              l_mono_flux_lim_thlm, &
@@ -530,6 +531,8 @@ module model_flags
       l_smooth_Heaviside_tau_wpxp,  & ! Use smoothed Heaviside 'Peskin' function
                                       ! in the calculation of H_invrs_tau_wpxp_N2
                                       ! in src/CLUBB_core/mixing_length.F90
+      l_modify_bc_for_cnvg_test,    & ! Flag to activate modifications on boundary condition for 
+                                      ! convergence test (surface fluxes computed at fixed 25m height) 
       l_enable_relaxed_clipping,    & ! Flag to relax clipping on wpxp in
                                       ! xm_wpxp_clipping_and_stats
       l_linearize_pbl_winds,        & ! Code to linearize PBL winds

--- a/src/CLUBB_core/model_flags.F90
+++ b/src/CLUBB_core/model_flags.F90
@@ -601,6 +601,7 @@ module model_flags
     l_use_tke_in_wp3_pr_turb_term = .false.
     l_use_tke_in_wp2_wp3_K_dfsn = .false.
     l_smooth_Heaviside_tau_wpxp = .false.
+    l_modify_bc_for_cnvg_test = .false. 
     l_enable_relaxed_clipping = .false.
     l_linearize_pbl_winds = .false.
     l_mono_flux_lim_thlm = .true.

--- a/src/CLUBB_core/version_clubb_core.txt
+++ b/src/CLUBB_core/version_clubb_core.txt
@@ -1,0 +1,76 @@
+commit b361c61e93c25e1a491a5ff4fdbe5cbcc1f0f735
+Author: Tyler Cernik <cernikt@msoe.edu>
+Date:   Sat Feb 11 14:41:23 2023 -0600
+
+    made graphing for netcdf_var collector general. #1040
+
+commit 47cd566e64abb0e774abd20c2ec97deed8dd3ab5
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Wed Feb 8 17:34:02 2023 -0700
+
+    Porting pdf_closure subroutine with OpenACC (#1059)
+    
+    * Porting pdf_closure subroutine with OpenACC
+    
+    OpenACC directives are added to pdf_closure subroutine. The necessary
+    structured data region is also added for optimzing data movement across
+    kernels. There is opportunity to task parallelize using streams and
+    will be explored in the future.
+    
+    Answers are bit for bit.
+    
+    * Fixing the copyin directives
+    
+    * Making work without managed memory.
+
+commit 7d6dfad026e40eaf30f29ffa17c23dfbed882040
+Author: huebler <huebler@uwm.edu>
+Date:   Thu Feb 2 15:50:27 2023 -0600
+
+    Removing sigma_sqd_w from the acc data copyout statement. This is a bug which was causing the code to crash when not using managed memory.
+
+commit c9a950dbbf76e82a3cda0ab2d65f29cd5f28df12
+Author: huebler <huebler@uwm.edu>
+Date:   Fri Jan 27 17:50:12 2023 -0600
+
+    GPUizing some helping procedures.
+
+commit 5850944600089fe2cb244ca1b08973231b6d91d3
+Author: Gunther Huebler <huebler@uwm.edu>
+Date:   Sat Feb 4 22:56:44 2023 -0600
+
+    Fixing bug, arrays given a dummy index in 0fafc6b0b1f1a6058d37bf3db4bb3708204504db are declared nsize, but are only used up to nlevels, thus we need the (1,1:nlevels) specifier when passing them. This issue was only caught by our _debug tests, so that's good evidence the new flags we added to initialize unused to memory was effective.
+
+commit 2f84d7c748f143990316004c66ebda5486de5752
+Author: Gunther Huebler <huebler@uwm.edu>
+Date:   Sat Feb 4 17:22:00 2023 -0600
+
+    Removing update_pressure from public list. This was causing compilation crashes. RESOLVED:8c7230fecb877d04fb129ef5e143e0993b4b29b1
+
+commit 8c7230fecb877d04fb129ef5e143e0993b4b29b1
+Author: huebler <huebler@uwm.edu>
+Date:   Thu Feb 2 13:06:52 2023 -0600
+
+    Removing update_pressure since it is no longer called anywhere in clubb or host models. The addition of this subroutine was discussed in larson-group/e3sm#6 and the removal of the call to it was discussed in larson-group/clubb#926.
+
+commit 0fafc6b0b1f1a6058d37bf3db4bb3708204504db
+Author: huebler <huebler@uwm.edu>
+Date:   Fri Jan 27 14:42:40 2023 -0600
+
+    Pushing column loop into calculate_thvm
+
+commit cfd87ac680ebb26e2fdb7b1aab7a8b8b4fc75320
+Author: Steffen Domke <sdomke@uwm.edu>
+Date:   Mon Jan 30 15:12:37 2023 -0600
+
+    Added option (-i) to run_tuner.bash script to enable pre-tuning standalone runs. README will be updated.
+
+commit 1025d807ab1f3d5e8d3a8deb72595f2314b1cec5
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Mon Jan 30 18:47:29 2023 +0100
+
+    Adds to dashboard a bar plot that separates nonlinear
+    
+    and linear contributions to bias removal.
+    
+    Also abbreviates the clubb parameter names in the plots.

--- a/src/G_unit_test_types/pdf_parameter_tests.F90
+++ b/src/G_unit_test_types/pdf_parameter_tests.F90
@@ -540,6 +540,8 @@ module pdf_parameter_tests
       l_smooth_Heaviside_tau_wpxp,  & ! Use smoothed Heaviside 'Preskin' function
                                       ! in the calculation of H_invrs_tau_wpxp_N2
                                       ! in src/CLUBB_core/mixing_length.F90
+      l_modify_bc_for_cnvg_test,    & ! Flag to activate modifications on boundary condition for
+                                      ! convergence test (surface fluxes computed at fixed 25m height)
       l_enable_relaxed_clipping,    & ! Flag to relax clipping on wpxp in
                                       ! xm_wpxp_clipping_and_stats
       l_linearize_pbl_winds,        & ! Code to linearize PBL winds
@@ -686,6 +688,7 @@ module pdf_parameter_tests
                                          l_use_tke_in_wp3_pr_turb_term, &
                                          l_use_tke_in_wp2_wp3_K_dfsn, &
                                          l_smooth_Heaviside_tau_wpxp, &
+                                         l_modify_bc_for_cnvg_test, & 
                                          l_enable_relaxed_clipping, &
                                          l_linearize_pbl_winds, &
                                          l_mono_flux_lim_thlm, &

--- a/src/G_unit_test_types/spurious_source_test.F90
+++ b/src/G_unit_test_types/spurious_source_test.F90
@@ -480,6 +480,8 @@ module spurious_source_test
       l_smooth_Heaviside_tau_wpxp,  & ! Use smoothed Heaviside 'Preskin' function
                                       ! in the calculation of H_invrs_tau_wpxp_N2
                                       ! in src/CLUBB_core/mixing_length.F90
+      l_modify_bc_for_cnvg_test,    & ! Flag to activate modifications on boundary condition for
+                                      ! convergence test (surface fluxes computed at fixed 25m height)
       l_enable_relaxed_clipping,    & ! Flag to relax clipping on wpxp in
                                       ! xm_wpxp_clipping_and_stats
       l_linearize_pbl_winds,        & ! Code to linearize PBL winds
@@ -602,6 +604,7 @@ module spurious_source_test
                                          l_use_tke_in_wp3_pr_turb_term, &
                                          l_use_tke_in_wp2_wp3_K_dfsn, &
                                          l_smooth_Heaviside_tau_wpxp, &
+                                         l_modify_bc_for_cnvg_test, & 
                                          l_enable_relaxed_clipping, &
                                          l_linearize_pbl_winds, &
                                          l_mono_flux_lim_thlm, &

--- a/src/SILHS/version_silhs.txt
+++ b/src/SILHS/version_silhs.txt
@@ -1,0 +1,76 @@
+commit b361c61e93c25e1a491a5ff4fdbe5cbcc1f0f735
+Author: Tyler Cernik <cernikt@msoe.edu>
+Date:   Sat Feb 11 14:41:23 2023 -0600
+
+    made graphing for netcdf_var collector general. #1040
+
+commit 47cd566e64abb0e774abd20c2ec97deed8dd3ab5
+Author: supreethms1809 <supreethms1809@gmail.com>
+Date:   Wed Feb 8 17:34:02 2023 -0700
+
+    Porting pdf_closure subroutine with OpenACC (#1059)
+    
+    * Porting pdf_closure subroutine with OpenACC
+    
+    OpenACC directives are added to pdf_closure subroutine. The necessary
+    structured data region is also added for optimzing data movement across
+    kernels. There is opportunity to task parallelize using streams and
+    will be explored in the future.
+    
+    Answers are bit for bit.
+    
+    * Fixing the copyin directives
+    
+    * Making work without managed memory.
+
+commit 7d6dfad026e40eaf30f29ffa17c23dfbed882040
+Author: huebler <huebler@uwm.edu>
+Date:   Thu Feb 2 15:50:27 2023 -0600
+
+    Removing sigma_sqd_w from the acc data copyout statement. This is a bug which was causing the code to crash when not using managed memory.
+
+commit c9a950dbbf76e82a3cda0ab2d65f29cd5f28df12
+Author: huebler <huebler@uwm.edu>
+Date:   Fri Jan 27 17:50:12 2023 -0600
+
+    GPUizing some helping procedures.
+
+commit 5850944600089fe2cb244ca1b08973231b6d91d3
+Author: Gunther Huebler <huebler@uwm.edu>
+Date:   Sat Feb 4 22:56:44 2023 -0600
+
+    Fixing bug, arrays given a dummy index in 0fafc6b0b1f1a6058d37bf3db4bb3708204504db are declared nsize, but are only used up to nlevels, thus we need the (1,1:nlevels) specifier when passing them. This issue was only caught by our _debug tests, so that's good evidence the new flags we added to initialize unused to memory was effective.
+
+commit 2f84d7c748f143990316004c66ebda5486de5752
+Author: Gunther Huebler <huebler@uwm.edu>
+Date:   Sat Feb 4 17:22:00 2023 -0600
+
+    Removing update_pressure from public list. This was causing compilation crashes. RESOLVED:8c7230fecb877d04fb129ef5e143e0993b4b29b1
+
+commit 8c7230fecb877d04fb129ef5e143e0993b4b29b1
+Author: huebler <huebler@uwm.edu>
+Date:   Thu Feb 2 13:06:52 2023 -0600
+
+    Removing update_pressure since it is no longer called anywhere in clubb or host models. The addition of this subroutine was discussed in larson-group/e3sm#6 and the removal of the call to it was discussed in larson-group/clubb#926.
+
+commit 0fafc6b0b1f1a6058d37bf3db4bb3708204504db
+Author: huebler <huebler@uwm.edu>
+Date:   Fri Jan 27 14:42:40 2023 -0600
+
+    Pushing column loop into calculate_thvm
+
+commit cfd87ac680ebb26e2fdb7b1aab7a8b8b4fc75320
+Author: Steffen Domke <sdomke@uwm.edu>
+Date:   Mon Jan 30 15:12:37 2023 -0600
+
+    Added option (-i) to run_tuner.bash script to enable pre-tuning standalone runs. README will be updated.
+
+commit 1025d807ab1f3d5e8d3a8deb72595f2314b1cec5
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Mon Jan 30 18:47:29 2023 +0100
+
+    Adds to dashboard a bar plot that separates nonlinear
+    
+    and linear contributions to bias removal.
+    
+    Also abbreviates the clubb parameter names in the plots.

--- a/src/clubb_driver.F90
+++ b/src/clubb_driver.F90
@@ -409,9 +409,7 @@ module clubb_driver
       vp2,     & ! v'^2 (momentum levels)                         [m^2/s^2]
       up3,     & ! u'^3 (thermodynamic levels)                    [m^3/s^3]
       vp3,     & ! v'^3 (thermodynamic levels)                    [m^3/s^3]
-      rtm,     & ! total water mixing ratio, r_t (thermo. levels) [kg/kg]
       wprtp,   & ! w' r_t' (momentum levels)                      [(kg/kg) m/s]
-      thlm,    & ! liq. water pot. temp., th_l (thermo. levels)   [K]
       wpthlp,  & ! w'th_l' (momentum levels)                      [(m/s) K]
       rtp2,    & ! r_t'^2 (momentum levels)                       [(kg/kg)^2]
       rtp3,    & ! r_t'^3 (thermodynamic levels)                  [(kg/kg)^3]
@@ -421,13 +419,16 @@ module clubb_driver
       wp2        ! w'^2 (momentum levels)                         [m^2/s^2]
     
     real( kind = core_rknd ), dimension(:,:), allocatable :: &
+      thvm,   & ! Virtual potential temperature                        [K]
+      exner,      & ! Exner function (thermodynamic levels)       [-]
+      rtm,     & ! total water mixing ratio, r_t (thermo. levels) [kg/kg]
+      thlm,    & ! liq. water pot. temp., th_l (thermo. levels)   [K]
       rcm,      & ! cloud water mixing ratio, r_c (thermo. levels) [kg/kg]
       wp3,      & ! w'^3 (thermodynamic levels)                    [m^3/s^3]
       delta_zm
     
     real( kind = core_rknd ), dimension(:), allocatable :: &
       p_in_Pa,    & ! Air pressure (thermodynamic levels)         [Pa]
-      exner,      & ! Exner function (thermodynamic levels)       [-]
       cloud_frac, & ! cloud fraction (thermodynamic levels)       [-]
       wpthvp,     & ! < w' th_v' > (momentum levels)              [kg/kg K]
       wp2thvp,    & ! < w'^2 th_v' > (thermodynamic levels)       [m^2/s^2 K]
@@ -445,7 +446,8 @@ module clubb_driver
       wp2vp2        ! w'^2 v'^2 (momentum levels)                 [m^4/s^4]
 
     real( kind = core_rknd ), dimension(:,:), allocatable ::  &
-      rho_ds_zt  ! Dry, static density on thermo. levels      [kg/m^3]
+      rho_ds_zt,  & ! Dry, static density on thermo. levels      [kg/m^3]
+      thv_ds_zt     ! Dry, base-state theta_v on thermo levs.    [K]
     
     real( kind = core_rknd ), dimension(:), allocatable ::  &
       wm_zm,           & ! vertical mean wind comp. on momentum levs  [m/s]
@@ -455,8 +457,7 @@ module clubb_driver
       rho_ds_zm,       & ! Dry, static density on momentum levels     [kg/m^3]
       invrs_rho_ds_zm, & ! Inverse dry, static density on m-levs.     [m^3/kg]
       invrs_rho_ds_zt, & ! Inverse dry, static density on thermo levs.[m^3/kg]
-      thv_ds_zm,       & ! Dry, base-state theta_v on momentum levs.  [K]
-      thv_ds_zt          ! Dry, base-state theta_v on thermo levs.    [K]
+      thv_ds_zm          ! Dry, base-state theta_v on momentum levs.  [K]
 
     real( kind = core_rknd ), dimension(:), allocatable ::  &
       thlm_forcing,    & ! liq. wat. pot. temp. forcing (thermo. levs)[K/s]
@@ -493,7 +494,6 @@ module clubb_driver
     real( kind = core_rknd ), dimension(:), allocatable :: &
       Ncm,    & ! Mean cloud droplet concentration, <N_c> (t-levs.)    [num/kg]
       Nccnm,  & ! Cloud condensation nuclei concentration (COAMPS/MG)  [num/kg]
-      thvm,   & ! Virtual potential temperature                        [K]
       em,     & ! Turbulent Kinetic Energy (TKE)                       [m^2/s^2]
       tau_zm, & ! Eddy dissipation time scale on momentum levels       [s]
       tau_zt, & ! Eddy dissipation time scale on thermodynamic levels  [s]
@@ -834,8 +834,8 @@ module clubb_driver
       l_smooth_Heaviside_tau_wpxp,  & ! Use smoothed Heaviside 'Preskin' function
                                       ! in the calculation of H_invrs_tau_wpxp_N2
                                       ! in src/CLUBB_core/mixing_length.F90
-      l_modify_bc_for_cnvg_test,    & ! Flag to activate modifications on boundary condition for 
-                                      ! convergence test (surface fluxes computed at fixed 25m height) 
+      l_modify_bc_for_cnvg_test,    & ! Flag to activate modifications on boundary condition for
+                                      ! convergence test (surface fluxes computed at fixed 25m height)
       l_enable_relaxed_clipping,    & ! Flag to relax clipping on wpxp in
                                       ! xm_wpxp_clipping_and_stats
       l_linearize_pbl_winds,        & ! Code to linearize PBL winds
@@ -870,8 +870,8 @@ module clubb_driver
       sclr_tol, sclr_dim, iisclr_thl, iisclr_rt, iisclr_CO2, &
       edsclr_dim, iiedsclr_thl, iiedsclr_rt, iiedsclr_CO2, &
       l_rtm_nudge, rtm_min, rtm_nudge_max_altitude, &
-      l_diagnose_correlations, l_calc_w_corr, & 
-      l_modify_bc_for_cnvg_test 
+      l_diagnose_correlations, l_calc_w_corr, &
+      l_modify_bc_for_cnvg_test
 
 
     namelist /stats_setting/ &
@@ -1528,8 +1528,8 @@ module clubb_driver
     allocate( vp2(1:gr%nz) )
     allocate( vp3(1:gr%nz) )
 
-    allocate( thlm(1:gr%nz) )      ! liquid potential temperature
-    allocate( rtm(1:gr%nz) )       ! total water mixing ratio
+    allocate( thlm(1,1:gr%nz) )      ! liquid potential temperature
+    allocate( rtm(1,1:gr%nz) )       ! total water mixing ratio
     allocate( wprtp(1:gr%nz) )     ! w'rt'
     allocate( wpthlp(1:gr%nz) )    ! w'thl'
     allocate( wprcp(1:gr%nz) )     ! w'rc'
@@ -1544,7 +1544,7 @@ module clubb_driver
     allocate( rtpthlp(1:gr%nz) )   ! rt'thlp'
 
     allocate( p_in_Pa(1:gr%nz) )         ! pressure (pascals)
-    allocate( exner(1:gr%nz) )           ! exner function
+    allocate( exner(1,1:gr%nz) )           ! exner function
     allocate( rho(1:gr%nz) )             ! density: t points
     allocate( rho_zm(1:gr%nz) )          ! density: m points
     allocate( rho_ds_zm(1:gr%nz) )       ! dry, static density: m-levs
@@ -1552,7 +1552,7 @@ module clubb_driver
     allocate( invrs_rho_ds_zm(1:gr%nz) ) ! inv. dry, static density: m-levs
     allocate( invrs_rho_ds_zt(1:gr%nz) ) ! inv. dry, static density: t-levs
     allocate( thv_ds_zm(1:gr%nz) )       ! dry, base-state theta_v: m-levs
-    allocate( thv_ds_zt(1:gr%nz) )       ! dry, base-state theta_v: t-levs
+    allocate( thv_ds_zt(1,1:gr%nz) )       ! dry, base-state theta_v: t-levs
 
     allocate( thlm_forcing(1:gr%nz) )    ! thlm ls forcing
     allocate( rtm_forcing(1:gr%nz) )     ! rtm ls forcing
@@ -1609,7 +1609,7 @@ module clubb_driver
     allocate( vm_ref(1:gr%nz) )         ! Reference v wind for nudging; Michael Falk, 17 Oct 2007
     allocate( thlm_ref(1:gr%nz) )       ! Reference liquid water potential for nudging
     allocate( rtm_ref(1:gr%nz) )        ! Reference total water mixing ratio for nudging
-    allocate( thvm(1:gr%nz) )           ! Virtual potential temperature
+    allocate( thvm(1,1:gr%nz) )           ! Virtual potential temperature
     allocate( radht(1:gr%nz) )          ! SW + LW heating rate
     allocate( Frad(1:gr%nz) )           ! radiative flux (momentum point)
     allocate( Frad_SW_up(1:gr%nz) )
@@ -1678,8 +1678,8 @@ module clubb_driver
     vp2(1:gr%nz)     = w_tol_sqd     ! v'^2
     vp3(1:gr%nz)     = zero          ! v'^3
 
-    thlm(1:gr%nz)    = zero          ! liquid potential temperature
-    rtm(1:gr%nz)     = zero          ! total water mixing ratio
+    thlm(1,1:gr%nz)    = zero          ! liquid potential temperature
+    rtm(1,1:gr%nz)     = zero          ! total water mixing ratio
     wprtp(1:gr%nz)   = zero          ! w'rt'
     wpthlp(1:gr%nz)  = zero          ! w'thl'
     wp2(1:gr%nz)     = w_tol_sqd     ! w'^2
@@ -1694,7 +1694,7 @@ module clubb_driver
     cloudy_downdraft_frac(1:gr%nz) = zero
 
     p_in_Pa(1:gr%nz)= zero           ! pressure (Pa)
-    exner(1:gr%nz) = zero            ! exner
+    exner(1,1:gr%nz) = zero            ! exner
     rho(1:gr%nz)  = zero             ! density on thermo. levels
     rho_zm(1:gr%nz)  = zero          ! density on moment. levels
     rho_ds_zm(1:gr%nz) = zero        ! dry, static density: m-levs
@@ -1702,7 +1702,7 @@ module clubb_driver
     invrs_rho_ds_zm(1:gr%nz) = zero  ! inv. dry, static density: m-levs
     invrs_rho_ds_zt(1:gr%nz) = zero  ! inv. dry, static density: t-levs
     thv_ds_zm(1:gr%nz) = zero        ! dry, base-state theta_v: m-levs
-    thv_ds_zt(1:gr%nz) = zero        ! dry, base-state theta_v: t-levs
+    thv_ds_zt(1,1:gr%nz) = zero        ! dry, base-state theta_v: t-levs
 
     thlm_forcing(1:gr%nz)    = zero  ! thlm large-scale forcing
     rtm_forcing(1:gr%nz)     = zero  ! rtm large-scale forcing
@@ -1978,19 +1978,19 @@ module clubb_driver
       iinit = 1
 
       call initialize_clubb &
-           ( gr, iunit, trim( forcings_file_path ), p_sfc, zm_init,  & ! Intent(in)
-             clubb_config_flags%l_uv_nudge,                      & ! Intent(in)
-             clubb_config_flags%l_tke_aniso,                     & ! Intent(in)
-             thlm, rtm, um, vm, ug, vg, wp2, up2, vp2, rcm(1,:), & ! Intent(inout)
-             wm_zt, wm_zm, em, exner,                            & ! Intent(inout)
-             thvm, p_in_Pa,                                      & ! Intent(inout)
-             rho, rho_zm, rho_ds_zm, rho_ds_zt(1,:),             & ! Intent(inout)
-             invrs_rho_ds_zm, invrs_rho_ds_zt,                   & ! Intent(inout)
-             thv_ds_zm, thv_ds_zt,                               & ! Intent(inout)
-             rtm_ref, thlm_ref,                                  & ! Intent(inout) 
-             um_ref, vm_ref,                                     & ! Intent(inout)
-             Ncm, Nc_in_cloud, Nccnm,                            & ! Intent(inout)
-             sclrm, edsclrm )                                      ! Intent(out)
+           ( gr, iunit, trim( forcings_file_path ), p_sfc, zm_init,         & ! Intent(in)
+             clubb_config_flags%l_uv_nudge,                                 & ! Intent(in)
+             clubb_config_flags%l_tke_aniso,                                & ! Intent(in)
+             thlm(1,:), rtm(1,:), um, vm, ug, vg, wp2, up2, vp2, rcm(1,:),  & ! Intent(inout)
+             wm_zt, wm_zm, em, exner(1,:),                                  & ! Intent(inout)
+             thvm(1,:), p_in_Pa,                                            & ! Intent(inout)
+             rho, rho_zm, rho_ds_zm, rho_ds_zt(1,:),                        & ! Intent(inout)
+             invrs_rho_ds_zm, invrs_rho_ds_zt,                              & ! Intent(inout)
+             thv_ds_zm, thv_ds_zt(1,:),                                     & ! Intent(inout)
+             rtm_ref, thlm_ref,                                             & ! Intent(inout) 
+             um_ref, vm_ref,                                                & ! Intent(inout)
+             Ncm, Nc_in_cloud, Nccnm,                                       & ! Intent(inout)
+             sclrm, edsclrm )                                                 ! Intent(out)
 
       if ( clubb_at_least_debug_level( 0 ) ) then
           if ( err_code == clubb_fatal_error ) then
@@ -2008,19 +2008,19 @@ module clubb_driver
       ! Therefore it should be executed prior to a restart. The restart should overwrite
       ! the initial sounding anyway.
       call initialize_clubb &
-           ( gr, iunit, trim( forcings_file_path ), p_sfc, zm_init,  & ! Intent(in)
-             clubb_config_flags%l_uv_nudge,                      & ! Intent(in)
-             clubb_config_flags%l_tke_aniso,                     & ! Intent(in)
-             thlm, rtm, um, vm, ug, vg, wp2, up2, vp2, rcm(1,:), & ! Intent(inout)
-             wm_zt, wm_zm, em, exner,                            & ! Intent(inout)
-             thvm, p_in_Pa,                                      & ! Intent(inout)
-             rho, rho_zm, rho_ds_zm, rho_ds_zt(1,:),             & ! Intent(inout)
-             invrs_rho_ds_zm, invrs_rho_ds_zt,                   & ! Intent(inout)
-             thv_ds_zm, thv_ds_zt,                               & ! Intent(inout)
-             rtm_ref, thlm_ref,                                  & ! Intent(inout) 
-             um_ref, vm_ref,                                     & ! Intent(inout)
-             Ncm, Nc_in_cloud, Nccnm,                            & ! Intent(inout)
-             sclrm, edsclrm )                                      ! Intent(out)
+           ( gr, iunit, trim( forcings_file_path ), p_sfc, zm_init,         & ! Intent(in)
+             clubb_config_flags%l_uv_nudge,                                 & ! Intent(in)
+             clubb_config_flags%l_tke_aniso,                                & ! Intent(in)
+             thlm(1,:), rtm(1,:), um, vm, ug, vg, wp2, up2, vp2, rcm(1,:),  & ! Intent(inout)
+             wm_zt, wm_zm, em, exner(1,:),                                  & ! Intent(inout)
+             thvm(1,:), p_in_Pa,                                            & ! Intent(inout)
+             rho, rho_zm, rho_ds_zm, rho_ds_zt(1,:),                        & ! Intent(inout)
+             invrs_rho_ds_zm, invrs_rho_ds_zt,                              & ! Intent(inout)
+             thv_ds_zm, thv_ds_zt(1,:),                                     & ! Intent(inout)
+             rtm_ref, thlm_ref,                                             & ! Intent(inout) 
+             um_ref, vm_ref,                                                & ! Intent(inout)
+             Ncm, Nc_in_cloud, Nccnm,                                       & ! Intent(inout)
+             sclrm, edsclrm )                                                 ! Intent(out)
 
       if ( clubb_at_least_debug_level( 0 ) ) then
           if ( err_code == clubb_fatal_error ) then
@@ -2053,31 +2053,31 @@ module clubb_driver
       iinit = floor( ( time_current - time_initial ) / real(dt_main,kind=time_precision) ) + 1
 
       call restart_clubb &
-           ( gr, iunit, runfile,                    & ! Intent(in)
-             restart_path_case, time_restart,          & ! Intent(in)
-             um, upwp, vm, vpwp, up2, vp2, rtm,        & ! Intent(inout)
-             wprtp, thlm, wpthlp, rtp2, rtp3,          & ! Intent(inout)
-             thlp2, thlp3, rtpthlp, wp2, wp3(1,:),     & ! Intent(inout)
-             p_in_Pa, exner, rcm(1,:), cloud_frac,     & ! Intent(inout)
-             wpthvp, wp2thvp, rtpthvp, thlpthvp,       & ! Intent(inout)
-             wp2rtp, wp2thlp, uprcp, vprcp,            & ! Intent(inout)
-             rc_coef, wp4, wpup2, wpvp2, wp2up2,       & ! Intent(inout)
-             wp2vp2, ice_supersat_frac,                & ! Intent(inout)
-             wm_zt, rho, rho_zm, rho_ds_zm,            & ! Intent(inout)
-             rho_ds_zt(1,:), thv_ds_zm, thv_ds_zt,     & ! Intent(inout)
-             thlm_forcing, rtm_forcing, wprtp_forcing, & ! Intent(inout)
-             wpthlp_forcing, rtp2_forcing,             & ! Intent(inout)
-             thlp2_forcing, rtpthlp_forcing,           & ! Intent(inout)
-             hydromet, hydrometp2, wphydrometp,        & ! Intent(inout)
-             Ncm, Nccnm, thvm, em, tau_zm, tau_zt,     & ! Intent(inout)
-             Kh_zt, Kh_zm, ug, vg, Lscale(1,:),        & ! Intent(inout)
-             Lscale_up, Lscale_down, thlprcp,          & ! Intent(inout)
-             sigma_sqd_w, sigma_sqd_w_zt, radht,       & ! Intent(inout)
-             pdf_params, pdf_params_zm,                & ! Intent(inout)
-             rcm_mc, rvm_mc, thlm_mc,                  & ! Intent(out)
-             wprtp_mc, wpthlp_mc, rtp2_mc,             & ! Intent(out)
-             thlp2_mc, rtpthlp_mc,                     & ! Intent(out)
-             wpthlp_sfc, wprtp_sfc, upwp_sfc, vpwp_sfc ) ! Intent(out)
+           ( gr, iunit, runfile,                            & ! Intent(in)
+             restart_path_case, time_restart,               & ! Intent(in)
+             um, upwp, vm, vpwp, up2, vp2, rtm(1,:),        & ! Intent(inout)
+             wprtp, thlm(1,:), wpthlp, rtp2, rtp3,          & ! Intent(inout)
+             thlp2, thlp3, rtpthlp, wp2, wp3(1,:),          & ! Intent(inout)
+             p_in_Pa, exner(1,:), rcm(1,:), cloud_frac,     & ! Intent(inout)
+             wpthvp, wp2thvp, rtpthvp, thlpthvp,            & ! Intent(inout)
+             wp2rtp, wp2thlp, uprcp, vprcp,                 & ! Intent(inout)
+             rc_coef, wp4, wpup2, wpvp2, wp2up2,            & ! Intent(inout)
+             wp2vp2, ice_supersat_frac,                     & ! Intent(inout)
+             wm_zt, rho, rho_zm, rho_ds_zm,                 & ! Intent(inout)
+             rho_ds_zt(1,:), thv_ds_zm, thv_ds_zt(1,:),     & ! Intent(inout)
+             thlm_forcing, rtm_forcing, wprtp_forcing,      & ! Intent(inout)
+             wpthlp_forcing, rtp2_forcing,                  & ! Intent(inout)
+             thlp2_forcing, rtpthlp_forcing,                & ! Intent(inout)
+             hydromet, hydrometp2, wphydrometp,             & ! Intent(inout)
+             Ncm, Nccnm, thvm(1,:), em, tau_zm, tau_zt,     & ! Intent(inout)
+             Kh_zt, Kh_zm, ug, vg, Lscale(1,:),             & ! Intent(inout)
+             Lscale_up, Lscale_down, thlprcp,               & ! Intent(inout)
+             sigma_sqd_w, sigma_sqd_w_zt, radht,            & ! Intent(inout)
+             pdf_params, pdf_params_zm,                     & ! Intent(inout)
+             rcm_mc, rvm_mc, thlm_mc,                       & ! Intent(out)
+             wprtp_mc, wpthlp_mc, rtp2_mc,                  & ! Intent(out)
+             thlp2_mc, rtpthlp_mc,                          & ! Intent(out)
+             wpthlp_sfc, wprtp_sfc, upwp_sfc, vpwp_sfc )      ! Intent(out)
  
       ! Calculate invrs_rho_ds_zm and invrs_rho_ds_zt from the values of
       ! rho_ds_zm and rho_ds_zt, respectively, which were read in from the input
@@ -2236,21 +2236,21 @@ module clubb_driver
              itime_nearest )                                     ! Intent(out)
 
         call stat_fields_reader( gr, max( itime_nearest, 1 ), & ! In
-                                 um, upwp, vm, vpwp, up2, vp2, rtm, & ! Inout
-                                 wprtp, thlm, wpthlp, rtp2, rtp3, & ! Inout
+                                 um, upwp, vm, vpwp, up2, vp2, rtm(1,:), & ! Inout
+                                 wprtp, thlm(1,:), wpthlp, rtp2, rtp3, & ! Inout
                                  thlp2, thlp3, rtpthlp, wp2, wp3(1,:), & ! Inout
-                                 p_in_Pa, exner, rcm(1,:), cloud_frac, & ! Inout
+                                 p_in_Pa, exner(1,:), rcm(1,:), cloud_frac, & ! Inout
                                  wpthvp, wp2thvp, rtpthvp, thlpthvp, & ! Inout
                                  wp2rtp, wp2thlp, uprcp, vprcp, & ! Inout
                                  rc_coef, wp4, wpup2, wpvp2, wp2up2, & ! Inout
                                  wp2vp2, ice_supersat_frac, & ! Inout
                                  wm_zt, rho, rho_zm, rho_ds_zm, & ! Inout
-                                 rho_ds_zt(1,:), thv_ds_zm, thv_ds_zt, & ! Inout
+                                 rho_ds_zt(1,:), thv_ds_zm, thv_ds_zt(1,:), & ! Inout
                                  thlm_forcing, rtm_forcing, wprtp_forcing, & !""
                                  wpthlp_forcing, rtp2_forcing, & ! Inout
                                  thlp2_forcing, rtpthlp_forcing, & ! Inout
                                  hydromet, hydrometp2, wphydrometp, & ! Inout
-                                 Ncm, Nccnm, thvm, em, tau_zm, tau_zt, & ! Inout
+                                 Ncm, Nccnm, thvm(1,:), em, tau_zm, tau_zt, & ! Inout
                                  Kh_zt, Kh_zm, ug, vg, Lscale(1,:), & ! Inout
                                  Lscale_up, Lscale_down, thlprcp, & ! Inout
                                  sigma_sqd_w, sigma_sqd_w_zt, radht, & ! Inout
@@ -2267,7 +2267,7 @@ module clubb_driver
 
       ! Check for NaN values in the model arrays
       if ( clubb_at_least_debug_level( 2 ) ) then
-        if ( invalid_model_arrays( gr%nz, um, vm, rtm, wprtp, thlm, wpthlp, &
+        if ( invalid_model_arrays( gr%nz, um, vm, rtm(1,:), wprtp, thlm(1,:), wpthlp, &
                                    rtp2, thlp2, rtpthlp, wp2, wp3(1,:), &
                                    wp2thvp, rtpthvp, thlpthvp, &
                                    hydromet, sclrm, edsclrm ) ) then
@@ -2284,14 +2284,16 @@ module clubb_driver
       l_calc_weights_all_levs_itime = l_calc_weights_all_levs .and. .not. l_rad_itime
 
       ! Calculate thvm for use in prescribe_forcings.
-      thvm = calculate_thvm( thlm, rtm, rcm(1,:), exner, thv_ds_zt )
+      call calculate_thvm( gr%nz, 1, &
+                           thlm, rtm, rcm, exner, thv_ds_zt, &
+                           thvm )
 
       ! Set large-scale tendencies and subsidence profiles
-      call prescribe_forcings( gr, dt_main, um, vm, thlm, & ! In
-                               p_in_Pa, exner, rho, rho_zm, thvm, & ! In
+      call prescribe_forcings( gr, dt_main, um, vm, thlm(1,:), & ! In
+                               p_in_Pa, exner(1,:), rho, rho_zm, thvm(1,:), & ! In
                                Frad_SW_up, Frad_SW_down, Frad_LW_down, & ! In
                                l_modify_bc_for_cnvg_test, & ! In
-                               rtm, wm_zm, wm_zt, ug, vg, um_ref, vm_ref, & ! Inout
+                               rtm(1,:), wm_zm, wm_zt, ug, vg, um_ref, vm_ref, & ! Inout
                                thlm_forcing, rtm_forcing, um_forcing, & ! Inout
                                vm_forcing, wprtp_forcing, wpthlp_forcing, & ! Inout
                                rtp2_forcing, thlp2_forcing, rtpthlp_forcing, & ! Inout
@@ -2364,9 +2366,9 @@ module clubb_driver
                wpsclrp_sfc, wpedsclrp_sfc,  &                                       ! Intent(in)
                upwp_sfc_pert, vpwp_sfc_pert, &                                      ! intent(in)
                rtm_ref, thlm_ref, um_ref, vm_ref, ug, vg, &                         ! Intent(in)
-               p_in_Pa, rho_zm, rho, exner, &                                       ! Intent(in)
+               p_in_Pa, rho_zm, rho, exner(1,:), &                                  ! Intent(in)
                rho_ds_zm, rho_ds_zt(1,:), invrs_rho_ds_zm, &                        ! Intent(in)
-               invrs_rho_ds_zt, thv_ds_zm, thv_ds_zt, hydromet, &                   ! Intent(in)
+               invrs_rho_ds_zt, thv_ds_zm, thv_ds_zt(1,:), hydromet, &              ! Intent(in)
                rfrzm, radf, wphydrometp, &                                          ! Intent(in)
                wp2hmp, rtphmp_zt, thlphmp_zt, &                                     ! Intent(in)
                dummy_dx, dummy_dy, &                                                ! Intent(in)
@@ -2374,7 +2376,7 @@ module clubb_driver
                clubb_config_flags, &                                                ! Intent(in)
                stats_zt, stats_zm, stats_sfc, &                                     ! intent(inout)
                um, vm, upwp, vpwp, up2, vp2, up3, vp3, &                            ! Intent(inout)
-               thlm, rtm, wprtp, wpthlp, &                                          ! Intent(inout)
+               thlm(1,:), rtm(1,:), wprtp, wpthlp, &                                ! Intent(inout)
                wp2, wp3(1,:), rtp2, rtp3, thlp2, thlp3, rtpthlp, &                  ! Intent(inout)
                sclrm, sclrp2, sclrp3, sclrprtp, sclrpthlp, &                        ! Intent(inout)
                wpsclrp, edsclrm, err_code_dummy, &                                  ! Intent(inout)
@@ -2413,9 +2415,9 @@ module clubb_driver
                wpsclrp_sfc, wpedsclrp_sfc,  &                                       ! Intent(in)
                upwp_sfc_pert, vpwp_sfc_pert, &                                      ! intent(in)
                rtm_ref, thlm_ref, um_ref, vm_ref, ug, vg, &                         ! Intent(in)
-               p_in_Pa, rho_zm, rho, exner, &                                       ! Intent(in)
+               p_in_Pa, rho_zm, rho, exner(1,:), &                                  ! Intent(in)
                rho_ds_zm, rho_ds_zt(1,:), invrs_rho_ds_zm, &                        ! Intent(in)
-               invrs_rho_ds_zt, thv_ds_zm, thv_ds_zt, hydromet, &                   ! Intent(in)
+               invrs_rho_ds_zt, thv_ds_zm, thv_ds_zt(1,:), hydromet, &              ! Intent(in)
                rfrzm, radf, wphydrometp, &                                          ! Intent(in)
                wp2hmp, rtphmp_zt, thlphmp_zt, &                                     ! Intent(in)
                dummy_dx, dummy_dy, &                                                ! Intent(in)
@@ -2423,7 +2425,7 @@ module clubb_driver
                clubb_config_flags, &                                                ! Intent(in)
                stats_zt, stats_zm, stats_sfc, &                                     ! intent(inout)
                um, vm, upwp, vpwp, up2, vp2, up3, vp3, &                            ! Intent(inout)
-               thlm, rtm, wprtp, wpthlp, &                                          ! Intent(inout)
+               thlm(1,:), rtm(1,:), wprtp, wpthlp, &                                ! Intent(inout)
                wp2, wp3(1,:), rtp2, rtp3, thlp2, thlp3, rtpthlp, &                  ! Intent(inout)
                sclrm, sclrp2, sclrp3, sclrprtp, sclrpthlp, &                        ! Intent(inout)
                wpsclrp, edsclrm, err_code_dummy, &                                  ! Intent(inout)
@@ -2619,7 +2621,7 @@ module clubb_driver
 
       ! Call microphysics scheme and produce microphysics tendencies.
       call calc_microphys_scheme_tendcies( gr, dt_main, time_current, pdf_dim, runtype, & ! In
-                              thlm, p_in_Pa, exner, rho, rho_zm, rtm, &               ! In
+                              thlm(1,:), p_in_Pa, exner(1,:), rho, rho_zm, rtm(1,:), &               ! In
                               rcm(1,:), cloud_frac, wm_zt, wm_zm, wp2_zt(1,:), &           ! In
                               hydromet, Nc_in_cloud, &                                ! In
                               pdf_params, hydromet_pdf_params(1,:), &                 ! In
@@ -2659,7 +2661,7 @@ module clubb_driver
 
       ! Advance predictive microphysics fields one model timestep.
       call advance_microphys( gr, dt_main, time_current, wm_zt, wp2,      & ! In
-                              exner, rho, rho_zm, rcm(1,:),               & ! In
+                              exner(1,:), rho, rho_zm, rcm(1,:),               & ! In
                               cloud_frac, Kh_zm, Skw_zm,                  & ! In
                               rho_ds_zm, rho_ds_zt(1,:), invrs_rho_ds_zt, & ! In
                               hydromet_mc, Ncm_mc, Lscale(1,:),           & ! In
@@ -2714,7 +2716,7 @@ module clubb_driver
           call silhs_radiation_driver &
                ( gr, gr%nz, lh_num_samples, pdf_dim, hydromet_dim,                & !In
                  time_current, time_initial, rho, rho_zm,                               & !In
-                 p_in_Pa, exner, cloud_frac, ice_supersat_frac, X_nl_all_levs(1,:,:,:), & !In
+                 p_in_Pa, exner(1,:), cloud_frac, ice_supersat_frac, X_nl_all_levs(1,:,:,:), & !In
                  lh_rt_clipped(1,:,:), lh_thl_clipped(1,:,:), lh_rc_clipped(1,:,:),     & !In
                  lh_sample_point_weights(1,:,:), hydromet,                              & !In
                  radht, Frad, Frad_SW_up, Frad_LW_up, Frad_SW_down, Frad_LW_down )        !out
@@ -2723,7 +2725,7 @@ module clubb_driver
 
           call advance_clubb_radiation &
                ( gr, time_current, time_initial, rho, rho_zm, p_in_Pa,             & ! In
-                 exner, cloud_frac, ice_supersat_frac, thlm, rtm, rcm(1,:), hydromet, & ! In
+                 exner(1,:), cloud_frac, ice_supersat_frac, thlm(1,:), rtm(1,:), rcm(1,:), hydromet, & ! In
                  radht, Frad, Frad_SW_up, Frad_LW_up,                                 & ! Out
                  Frad_SW_down, Frad_LW_down )                                           ! Out
 
@@ -3096,6 +3098,11 @@ module clubb_driver
       l_tke_aniso   ! For anisotropic turbulent kinetic energy, i.e. TKE = 1/2 (u'^2 + v'^2 + w'^2)
 
     ! Output
+    real( kind = core_rknd ), dimension(1,gr%nz), intent(inout) ::  & 
+      exner,           & ! Exner function (thermodynamic levels)     [-] 
+      thvm,            & ! Virtual potential temp. (thermo. levs.)   [K]
+      rcm                ! Cloud water mixing ratio (thermo. levs.)  [kg/kg]
+
     real( kind = core_rknd ), dimension(gr%nz), intent(inout) ::  & 
       thlm,            & ! Grid mean of liquid water pot. temp               [K] 
       rtm,             & ! Grid mean of total water mixing ratio             [kg/kg]
@@ -3106,11 +3113,8 @@ module clubb_driver
       wp2,             & ! Vertical velocity variance (w'^2)                 [m^2/s^2]
       up2,             & ! East-west velocity variance (u'^2)                [m^2/s^2]
       vp2,             & ! North-south velocity variance (v'^2)              [m^2/s^2]
-      rcm,             & ! Cloud water mixing ratio                          [kg/kg]
       wm_zt, wm_zm,    & ! Vertical wind                                     [m/s]
       em,              & ! Turbulence kinetic energy                         [m^2/s^2]
-      exner,           & ! Exner function                                    [-] 
-      thvm,            & ! Virtual potential temperature                     [K]
       p_in_Pa,         & ! Pressure                                          [Pa]
       rho,             & ! Density (thermodynamic levels)                    [kg/m^3]
       rho_zm,          & ! Density on momentum levels                        [kg/m^3]
@@ -3193,7 +3197,7 @@ module clubb_driver
     Nc_in_cloud = Nc0_in_cloud / rho
     do k = 1, gr%nz, 1
 
-       if ( rcm(k) > zero ) then
+       if ( rcm(1,k) > zero ) then
 
           ! The initial profile at this level is entirely saturated (due to
           ! constant moisture and temperature over the level).  The level is
@@ -3757,22 +3761,26 @@ module clubb_driver
       rtm_sfc !,& ! Surface total water mixing ratio               [kg/kg]
 !     thlm_sfc    ! Surface liquid water potential temperature     [K]
 
-    real( kind = core_rknd ), dimension(gr%nz), intent(in) ::  &
+    real( kind = core_rknd ), dimension(1,gr%nz), intent(in) ::  &
       rtm    ! Total water mixing ratio (thermodynamic levels)    [kg/kg]
 
     ! Input/Output Variables
+    real( kind = core_rknd ), dimension(1,gr%nz), intent(inout) ::  &
+      thlm       ! Liquid water potential temperature (thermo. levs.)  [K] 
+
     real( kind = core_rknd ), dimension(gr%nz), intent(inout) ::  &
-      thlm,    & ! Liquid water potential temperature (thermo. levs.)  [K] 
       p_in_Pa    ! Pressure (thermodynamic levels)                     [Pa]
 
     ! Output Variables
+    real( kind = core_rknd ), dimension(1,gr%nz), intent(out) ::  &
+      exner,           & ! Exner function (thermodynamic levels)     [-] 
+      thvm,            & ! Virtual potential temp. (thermo. levs.)   [K]
+      rcm                ! Cloud water mixing ratio (thermo. levs.)  [kg/kg]
+
     real( kind = core_rknd ), dimension(gr%nz), intent(out) ::  &
       p_in_Pa_zm,      & ! Pressure (momentum levels)                [Pa]
-      exner,           & ! Exner function (thermodynamic levels)     [-] 
       rho,             & ! Density (thermodynamic levels)            [kg/m^3]
       rho_zm,          & ! Density on momentum levels                [kg/m^3]
-      rcm,             & ! Cloud water mixing ratio (thermo. levs.)  [kg/kg]
-      thvm,            & ! Virtual potential temp. (thermo. levs.)   [K]
       rho_ds_zm,       & ! Dry, static density (momentum levels)     [kg/m^3]
       rho_ds_zt,       & ! Dry, static density (thermodynamic levs.) [kg/m^3]
       invrs_rho_ds_zm, & ! Inverse dry, static density (m-levs.)     [m^3/kg]
@@ -3791,8 +3799,10 @@ module clubb_driver
       pd_sfc, & ! Dry surface pressure                [Pa]
       rv_sfc    ! Surface water vapor mixing ratio    [kg/kg]
 
+    real( kind = core_rknd ), dimension(1,gr%nz) ::  &
+      thm             ! Potential temperature (thermodynamic levels)   [K]
+
     real( kind = core_rknd ), dimension(gr%nz) ::  &
-      thm,          & ! Potential temperature (thermodynamic levels)   [K]
       exner_zm,     & ! Exner on momentum levels                       [-]
       th_dry,       & ! Dry potential temperature (thermo. levels)     [K]
       p_dry,        & ! Dry air pressure (thermodynamic levels)        [Pa]
@@ -3812,7 +3822,7 @@ module clubb_driver
     if ( rtm_sfc < 0.0_core_rknd ) then
       ! The sounding doesn't extended to the surface, so rtm_sfc is set to a
       ! negative number.  Use rtm(1) as rv_sfc.
-      rv_sfc = rtm(1)
+      rv_sfc = rtm(1,1)
     else ! rtm_sfc >= 0.0_core_rknd
       ! The sounding does extended to the surface, so rtm_sfc is the initial value
       ! of total water mixing ratio at the surface.
@@ -3845,7 +3855,7 @@ module clubb_driver
           ! calculation.  After this calculation, the variable "thlm" will
           ! actually contain potential temperature.
           do k = 1, gr%nz, 1
-             thlm(k) = thlm(k) / ( p_in_Pa(k) / p0 )**kappa
+             thlm(1,k) = thlm(1,k) / ( p_in_Pa(k) / p0 )**kappa
           enddo
 
        else
@@ -3889,14 +3899,14 @@ module clubb_driver
     ! is important to allow the ensuing computation of initial r_c is done as
     ! accurately as possible.
     do k = 1, gr%nz, 1
-       thvm(k) = thlm(k) * ( one + ep1 * ( rtm(k) / ( one + rtm(k) ) ) )
+       thvm(1,k) = thlm(1,k) * ( one + ep1 * ( rtm(1,k) / ( one + rtm(1,k) ) ) )
     enddo
 
     ! Compute approximate pressure, exner, and density using an approximate
     ! value of theta_v.
     call hydrostatic( gr, thvm, p_sfc,         & ! Intent(in)
                       p_in_Pa, p_in_Pa_zm, & ! Intent(out)
-                      exner, exner_zm,     & ! Intent(out)
+                      exner(1,:), exner_zm,     & ! Intent(out)
                       rho, rho_zm          ) ! Intent(out)
 
 
@@ -3906,14 +3916,14 @@ module clubb_driver
 
        ! The variable "thlm" actually contains potential temperature (theta)
        ! at this point.
-       thm = thlm
+       thm(1,:) = thlm(1,:)
 
        ! Calculate cloud water mixing ratio based on total water mixing ratio
        ! and saturation mixing ratio, which based total pressure and
        ! temperature, which is equal to theta * exner.
        do k = 1, gr%nz
-          rcm(k) &
-          = max( rtm(k) - sat_mixrat_liq( p_in_Pa(k), thm(k) * exner(k) ), &
+          rcm(1,k) &
+          = max( rtm(1,k) - sat_mixrat_liq( p_in_Pa(k), thm(1,k) * exner(1,k) ), &
                  zero_threshold )
        enddo
 
@@ -3921,15 +3931,15 @@ module clubb_driver
        ! in variable thlm) and cloud water mixing ratio (rcm), such that:
        !  theta_l = theta - [Lv/(Cp*exner)]*rcm.
        do k = 1, gr%nz
-          thlm(k) = thlm(k) - Lv/(Cp*exner(k)) * rcm(k)
+          thlm(1,k) = thlm(1,k) - Lv/(Cp*exner(1,k)) * rcm(1,k)
        enddo
 
        ! Testing of passive scalars
        if ( iisclr_thl > 0 ) then
-          sclrm(:,iisclr_thl) = thlm
+          sclrm(:,iisclr_thl) = thlm(1,:)
        endif
        if ( iiedsclr_thl > 0 ) then
-          edsclrm(:,iiedsclr_thl) = thlm
+          edsclrm(:,iiedsclr_thl) = thlm(1,:)
        endif
 
 
@@ -3948,20 +3958,20 @@ module clubb_driver
        ! Find mean cloud water mixing ratio.
        do k = 1, gr%nz, 1
           ! Compute cloud water mixing ratio using an iterative method.
-          rcm(k) = rcm_sat_adj( thlm(k), rtm(k), p_in_Pa(k), exner(k) )
+          rcm(1,k) = rcm_sat_adj( thlm(1,k), rtm(1,k), p_in_Pa(k), exner(1,k) )
        enddo
 
        ! Compute initial theta.
        do k = 1, gr%nz, 1
-          thm(k) = thlm(k) + Lv/(Cp*exner(k)) * rcm(k)
+          thm(1,k) = thlm(1,k) + Lv/(Cp*exner(1,k)) * rcm(1,k)
        enddo
 
        ! Testing of passive scalars
        if ( iisclr_thl > 0 ) then
-          sclrm(:,iisclr_thl) = thlm
+          sclrm(:,iisclr_thl) = thlm(1,:)
        endif
        if ( iiedsclr_thl > 0 ) then
-          edsclrm(:,iiedsclr_thl) = thlm
+          edsclrm(:,iiedsclr_thl) = thlm(1,:)
        endif
 
 
@@ -4012,14 +4022,16 @@ module clubb_driver
     !                   + [ {L_v/(C_p*exner)} - (R_v/R_d) * thv_ds ] * r_c;
     !
     ! where thv_ds is used as a reference value to approximate theta_l.
-    thvm = calculate_thvm( thlm, rtm, rcm, exner, &
-                           thm * ( one + ep2 * ( rtm - rcm ) )**kappa )
+    call calculate_thvm( gr%nz, 1, &
+                         thlm, rtm, rcm, exner, &
+                         thm * ( one + ep2 * ( rtm - rcm ) )**kappa, &
+                         thvm )
 
     ! Recompute more accurate initial exner function, pressure, and density
     ! using thvm, which includes the effects of water vapor and cloud water.
-    call hydrostatic( gr, thvm, p_sfc,          & ! Intent(in)
+    call hydrostatic( gr, thvm(1,:), p_sfc,          & ! Intent(in)
                       p_in_Pa, p_in_Pa_zm, &  ! Intent(out)
-                      exner, exner_zm,     &  ! Intent(out)
+                      exner(1,:), exner_zm,     &  ! Intent(out)
                       rho, rho_zm          )  ! Intent(out)
 
 
@@ -4033,7 +4045,7 @@ module clubb_driver
 
        ! Calculate dry pressure from total pressure and water vapor mixing
        ! ratio, such that:  p_d = p / [ 1 + (R_v/R_d)*r_v ].
-       p_dry(k) = p_in_Pa(k) / ( one + ep2 * ( rtm(k) - rcm(k) ) )
+       p_dry(k) = p_in_Pa(k) / ( one + ep2 * ( rtm(1,k) - rcm(1,k) ) )
 
        ! Calculate dry exner from dry pressure.
        exner_dry(k) = ( p_dry(k) / p0 )**kappa
@@ -4072,7 +4084,7 @@ module clubb_driver
     ! exner yields dry theta, which differs by actual theta by a small
     ! amount, which is given by the equations above.
     do k = 1, gr%nz, 1
-       th_dry(k) = thm(k) * ( one + ep2 * ( rtm(k) - rcm(k) ) )**kappa
+       th_dry(k) = thm(1,k) * ( one + ep2 * ( rtm(1,k) - rcm(1,k) ) )**kappa
     enddo
 
     ! Compute dry density using dry pressure, dry exner, and theta_d.
@@ -4090,7 +4102,7 @@ module clubb_driver
        ! momentum levels) and water vapor mixing ratio (interpolated to
        ! momentum levels), such that:  p_d = p / [ 1 + (R_v/R_d)*r_v ].
        p_dry_zm(k) = p_in_Pa_zm(k) &
-                     / ( one + ep2 * max( zt2zm( gr, rtm - rcm, k ), &
+                     / ( one + ep2 * max( zt2zm( gr, rtm(1,:) - rcm(1,:), k ), &
                                           zero_threshold ) )
     enddo
 
@@ -4103,8 +4115,8 @@ module clubb_driver
     ! Calculate theta_d on momentum levels by interpolating theta and water
     ! vapor mixing ratio to momentum levels.
     do k = 1, gr%nz, 1
-       th_dry_zm(k) = zt2zm( gr, thm, k ) &
-                      * ( one + ep2 * max( zt2zm( gr, rtm - rcm, k ), &
+       th_dry_zm(k) = zt2zm( gr, thm(1,:), k ) &
+                      * ( one + ep2 * max( zt2zm( gr, rtm(1,:) - rcm(1,:), k ), &
                                            zero_threshold ) )**kappa
     enddo
 
@@ -4774,7 +4786,7 @@ module clubb_driver
   subroutine prescribe_forcings( gr, dt, um, vm, thlm, &
                                  p_in_Pa, exner, rho, rho_zm, thvm, &
                                  Frad_SW_up, Frad_SW_down, Frad_LW_down, &
-                                 l_modify_bc_for_cnvg_test, & 
+                                 l_modify_bc_for_cnvg_test, &
                                  rtm, wm_zm, wm_zt, ug, vg, um_ref, vm_ref, &
                                  thlm_forcing, rtm_forcing, um_forcing, &
                                  vm_forcing, wprtp_forcing, wpthlp_forcing, &
@@ -4908,6 +4920,10 @@ module clubb_driver
     real(kind=core_rknd), intent(in) :: & 
       dt         ! Model timestep         [s]
 
+    logical, intent(in) :: &
+      l_modify_bc_for_cnvg_test ! Flag to activate modifications on boundary condition for
+                                ! convergence test (surface fluxes computed at fixed 25m height)
+
     real( kind = core_rknd ), dimension(gr%nz), intent(in) :: &
       um,           & ! eastward grid-mean wind component (thermo. levs.)  [m/s]
       vm,           & ! northward grid-mean wind component (thermo. levs.) [m/s]
@@ -4920,10 +4936,6 @@ module clubb_driver
       Frad_SW_up,   & ! SW radiative upwelling flux                        [W/m^2]
       Frad_SW_down, & ! SW radiative downwelling flux                      [W/m^2]
       Frad_LW_down    ! LW radiative downwelling flux                      [W/m^2]
-
-    logical, intent(in) :: &
-      l_modify_bc_for_cnvg_test ! Flag to activate modifications on boundary condition for 
-                                ! convergence test (surface fluxes computed at fixed 25m height) 
 
     real( kind = core_rknd ), dimension(gr%nz), intent(inout) :: &
       rtm,             & ! total water mixing ratio, r_t (thermo. levs.) [kg/kg]
@@ -4984,10 +4996,11 @@ module clubb_driver
     logical :: &
       l_compute_momentum_flux, &
       l_set_sclr_sfc_rtm_thlm, &
-      l_fixed_flux 
- 
-    ! local variable to store the values used to implement the modified 
-    ! boundary conditions for convergence test 
+      l_fixed_flux            
+
+    ! local variable to store the values at fixed model height 
+    ! used to calculate surface fluxes in order to implement the 
+    ! modified boundary conditions for convergence test
     real( kind = core_rknd ) :: &
       um_bot, &
       vm_bot, &
@@ -4996,7 +5009,6 @@ module clubb_driver
       rho_bot, &
       exner_bot, &
       z_bot
-          
 
 !-----------------------------------------------------------------------
 
@@ -5133,41 +5145,40 @@ module clubb_driver
     ! Compute Surface Fluxes
     !----------------------------------------------------------------
 
-
-    ! A new subrutine is added here to derive the pysical quantities at 
-    ! bottom model level that are used for computing the surface fluxes   
+    ! A new subrutine is added here to derive the pysical quantities at
+    ! bottom model level that are used for computing the surface fluxes
     ! (i.e. boundary conditions)
+
     call read_surface_var_for_bc( gr, um, vm, rtm, thlm, rho_zm, exner, & ! Intent(in)
                                   l_modify_bc_for_cnvg_test, & ! Intent(in)
-                                  z_bot, um_bot, vm_bot, rtm_bot, & ! Intent (out) 
-                                  thlm_bot, rho_bot, exner_bot ) ! Intent (out) 
-
+                                  z_bot, um_bot, vm_bot, rtm_bot, & ! Intent (out)
+                                  thlm_bot, rho_bot, exner_bot ) ! Intent (out)
 
     ! Boundary conditions for the second order moments
 
-    ubar = compute_ubar( um(2), vm(2) )
+    ubar = compute_ubar( um_bot, vm_bot )
 
     select case ( trim( runtype ) )
 
     case ( "rico" )
       l_set_sclr_sfc_rtm_thlm = .true.
-      call rico_sfclyr( time_current, um(2), vm(2), thlm(2), rtm(2),  & ! Intent(in)
+      call rico_sfclyr( time_current, um_bot, vm_bot, thlm_bot, rtm_bot, & ! Intent(in)
                           ! 299.8_core_rknd K is the RICO T_sfc;
                           ! 101540 Pa is the sfc pressure.
                           !gr%zt(1,2), 299.8_core_rknd, 101540._core_rknd,  &           ! Intent(in)
-                        gr%zt(1,2), p_sfc, exner(1), &                    ! Intent(in)
+                        z_bot, p_sfc, exner_bot, &                      ! Intent(in)
                         upwp_sfc, vpwp_sfc, wpthlp_sfc, &               ! Intent(out)
                         wprtp_sfc, ustar, T_sfc )                       ! Intent(out)
 
     case ( "gabls3" )
       l_compute_momentum_flux = .true.
       call gabls3_sfclyr( ubar, veg_T_in_K,      &               ! Intent(in)
-                          thlm(2), rtm(2), gr%zt(1,2), exner(1), & ! Intent(in)
+                          thlm_bot, rtm_bot, z_bot, exner_bot, & ! Intent(in)
                           wpthlp_sfc, wprtp_sfc, ustar )         ! Intent(out)
 
     case ( "gabls3_night" )
-      call gabls3_night_sfclyr( time_current, um(2), vm(2),    & ! Intent(in)
-                          thlm(2), rtm(2), gr%zt(1,2),           & ! Intent(in)
+      call gabls3_night_sfclyr( time_current, um_bot, vm_bot,  & ! Intent(in)
+                          thlm_bot, rtm_bot, z_bot,            & ! Intent(in)
                           upwp_sfc, vpwp_sfc,                  & ! Intent(out)
                           wpthlp_sfc, wprtp_sfc, ustar )         ! Intent(out)
     case ( "jun25_altocu" )
@@ -5183,8 +5194,8 @@ module clubb_driver
 
     case ( "cobra" )
       l_compute_momentum_flux = .true.
-      call cobra_sfclyr( time_current, gr%zt(1,2), rho_zm(1), &      ! Intent(in)
-                         thlm(2), ubar,                     &      ! Intent(in)
+      call cobra_sfclyr( time_current, z_bot, rho_bot,      &      ! Intent(in)
+                         thlm_bot, ubar,                    &      ! Intent(in)
                          wpthlp_sfc, wprtp_sfc, ustar,      &      ! Intent(out)
                          wpsclrp_sfc, wpedsclrp_sfc, T_sfc )       ! Intent(out)
     case ( "clex9_nov02" )
@@ -5211,8 +5222,8 @@ module clubb_driver
 
     case ( "astex_a209" )
       l_compute_momentum_flux = .true.
-      call astex_a209_sfclyr( time_current, ubar, rtm(2), &     ! Intent(in)
-                          thlm(2), gr%zt(1,2), exner(1), p_sfc, & ! Intent(in)
+      call astex_a209_sfclyr( time_current, ubar, rtm_bot, &    ! Intent(in)
+                          thlm_bot, z_bot, exner_bot, p_sfc, &  ! Intent(in)
                           wpthlp_sfc, wprtp_sfc, ustar, T_sfc ) ! Intent(out)
 
     case ( "nov11_altocu" )
@@ -5233,16 +5244,16 @@ module clubb_driver
                                     rtm )                             ! (inout)
 
       ! Read in time dependent inputs
-      call nov11_altocu_read_t_dependent( time_current, &             ! Intent(in)
-                                          sens_ht, latent_ht )        ! Intent(out)
+      call nov11_altocu_read_t_dependent( time_current, &      ! Intent(in)
+                                          sens_ht, latent_ht ) ! Intent(out)
 
     case ( "fire", "generic" )  ! Generic setup, and GCSS FIRE
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
       l_fixed_flux            = .true.
-      call fire_sfclyr( time_current, ubar, p_sfc,            &       ! Intent(in)
-                        thlm(2), rtm(2), exner(1),   &                ! Intent(in)
-                        wpthlp_sfc, wprtp_sfc, ustar, T_sfc )         ! Intent(out)
+      call fire_sfclyr( time_current, ubar, p_sfc,           & ! Intent(in)
+                        thlm_bot, rtm_bot, exner_bot,        & ! Intent(in)
+                        wpthlp_sfc, wprtp_sfc, ustar, T_sfc )  ! Intent(out)
 
     case ( "cloud_feedback_s6", "cloud_feedback_s6_p2k",   &
            "cloud_feedback_s11", "cloud_feedback_s11_p2k", &
@@ -5252,65 +5263,65 @@ module clubb_driver
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
       l_fixed_flux            = .true.
-      call cloud_feedback_sfclyr( time_current, sfctype, &  ! Intent(in)
-                                  thlm(2), rtm(2), gr%zt(1,2),   &     ! Intent(in)
-                                  ubar, p_sfc, T_sfc,            &   ! Intent(in)
-                                  wpthlp_sfc, wprtp_sfc, ustar)      ! Intent(out)
+      call cloud_feedback_sfclyr( time_current, sfctype,       & ! Intent(in)
+                                  thlm_bot, rtm_bot, z_bot,    & ! Intent(in)
+                                  ubar, p_sfc, T_sfc,          & ! Intent(in)
+                                  wpthlp_sfc, wprtp_sfc, ustar)  ! Intent(out)
 
     case ( "arm" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
       rho_sfc = 1.1_core_rknd
-      call arm_sfclyr( time_current, gr%zt(1,2), rho_sfc,  &   ! Intent(in)
-                        thlm(2), ubar,               &       ! Intent(in)
-                        wpthlp_sfc, wprtp_sfc, ustar )       ! Intent(out)
+      call arm_sfclyr( time_current, z_bot, rho_sfc,   & ! Intent(in)
+                        thlm_bot, ubar,                & ! Intent(in)
+                        wpthlp_sfc, wprtp_sfc, ustar )   ! Intent(out)
 
     case ( "arm_0003" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call arm_0003_sfclyr( time_current, gr%zt(1,2), rho_zm(1), &  ! Intent(in)
-                            thlm(2), ubar,                     &  ! Intent(in)
-                            wpthlp_sfc, wprtp_sfc, ustar )        ! Intent(out)
+      call arm_0003_sfclyr( time_current, z_bot, rho_bot, & ! Intent(in)
+                            thlm_bot, ubar,               & ! Intent(in)
+                            wpthlp_sfc, wprtp_sfc, ustar )  ! Intent(out)
     case ( "arm_3year" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call arm_3year_sfclyr( time_current, gr%zt(1,2), rho_zm(1), & ! Intent(in)
-                              thlm(2), ubar,                    & ! Intent(in)
-                              wpthlp_sfc, wprtp_sfc, ustar) ! Intent(out)
+      call arm_3year_sfclyr( time_current, z_bot, rho_bot, & ! Intent(in)
+                             thlm_bot, ubar,               & ! Intent(in)
+                             wpthlp_sfc, wprtp_sfc, ustar)   ! Intent(out)
     case ( "mc3e" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call arm_97_sfclyr( time_current, gr%zt(1,2), rho_zm(1), &   ! Intent(in)
-                          thlm(2), ubar,                     &   ! Intent(in)
-                          wpthlp_sfc, wprtp_sfc, ustar )         ! Intent(out)
+      call arm_97_sfclyr( time_current, z_bot, rho_bot, & ! Intent(in)
+                          thlm_bot, ubar,               & ! Intent(in)
+                          wpthlp_sfc, wprtp_sfc, ustar )  ! Intent(out)
 
     case ( "arm_97" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call arm_97_sfclyr( time_current, gr%zt(1,2), rho_zm(1), &   ! Intent(in)
-                          thlm(2), ubar,                     &   ! Intent(in)
-                          wpthlp_sfc, wprtp_sfc, ustar )         ! Intent(out)
+      call arm_97_sfclyr( time_current, z_bot, rho_bot, & ! Intent(in)
+                          thlm_bot, ubar,               & ! Intent(in)
+                          wpthlp_sfc, wprtp_sfc, ustar )  ! Intent(out)
 
 
     case ( "atex" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call atex_sfclyr( time_current, ubar,          &         ! Intent(in)
-                        thlm(2), rtm(2), exner(1),   &         ! Intent(in)
-                        wpthlp_sfc, wprtp_sfc, ustar, T_sfc )  ! Intent(out)
+      call atex_sfclyr( time_current, ubar,          &        ! Intent(in)
+                        thlm_bot, rtm_bot, exner_bot, &       ! Intent(in)
+                        wpthlp_sfc, wprtp_sfc, ustar, T_sfc ) ! Intent(out)
 
     case ( "bomex" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call bomex_sfclyr( time_current, rtm(2),                      &  ! Intent(in) 
-                         wpthlp_sfc, wprtp_sfc, ustar )                ! Intent(out)
+      call bomex_sfclyr( time_current, rtm_bot, &       ! Intent(in) 
+                         wpthlp_sfc, wprtp_sfc, ustar ) ! Intent(out)
 
     case ( "dycoms2_rf01" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
       call dycoms2_rf01_sfclyr( time_current, sfctype, p_sfc, &       ! Intent(in)
-                                exner(1), ubar,              &        ! Intent(in)
-                                thlm(2), rtm(2), rho_zm(1),  &        ! Intent(in)
+                                exner_bot, ubar,              &       ! Intent(in)
+                                thlm_bot, rtm_bot, rho_bot,   &       ! Intent(in)
                                 wpthlp_sfc, wprtp_sfc, ustar, T_sfc ) ! Intent(out)
     case ( "dycoms2_rf02" )
       l_compute_momentum_flux = .true.
@@ -5321,43 +5332,43 @@ module clubb_driver
     case ( "gabls2" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call gabls2_sfclyr( time_current, time_initial, &              ! Intent(in)
-                          gr%zt(1,2), p_sfc, &                         ! Intent(in)
-                          ubar, thlm(2), rtm(2), exner(1), &         ! Intent(in)
-                          wpthlp_sfc, wprtp_sfc, ustar, T_sfc )      ! Intent(out)
+      call gabls2_sfclyr( time_current, time_initial, &         ! Intent(in)
+                          z_bot, p_sfc, &                       ! Intent(in)
+                          ubar, thlm_bot, rtm_bot, exner_bot, & ! Intent(in)
+                          wpthlp_sfc, wprtp_sfc, ustar, T_sfc ) ! Intent(out)
 
     case ( "lba" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call lba_sfclyr( time_current, time_initial, gr%zt(1,2), &  ! Intent(in)
-                       rho_zm(1), thlm(2), ubar, &              ! Intent(in)
-                       wpthlp_sfc, wprtp_sfc, ustar )           ! Intent(out)
+      call lba_sfclyr( time_current, time_initial, z_bot, &  ! Intent(in)
+                       rho_bot, thlm_bot, ubar, &            ! Intent(in)
+                       wpthlp_sfc, wprtp_sfc, ustar )        ! Intent(out)
 
     case ( "mpace_a" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call mpace_a_sfclyr( time_current, rho_zm(1),      & ! Intent(in)
+      call mpace_a_sfclyr( time_current, rho_bot,        & ! Intent(in)
                             wpthlp_sfc, wprtp_sfc, ustar ) ! Intent(out)
     case ( "mpace_b" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call mpace_b_sfclyr( time_current, rho_zm(1), &      ! Intent(in)
+      call mpace_b_sfclyr( time_current, rho_bot, &        ! Intent(in)
                             wpthlp_sfc, wprtp_sfc, ustar ) ! Intent(out)
 
     case ( "neutral" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call neutral_case_sfclyr( time_current, gr%zt(1,2), thlm(2), & ! Intent(in)
-                                um(2), vm(2), ubar,              & ! Intent(in)
-                                upwp_sfc, vpwp_sfc, &              ! Intent(out)
-                                wpthlp_sfc, wprtp_sfc, ustar )     ! Intent(out)
+      call neutral_case_sfclyr( time_current, z_bot, thlm_bot, & ! Intent(in)
+                                um_bot, vm_bot, ubar,          & ! Intent(in)
+                                upwp_sfc, vpwp_sfc, &            ! Intent(out)
+                                wpthlp_sfc, wprtp_sfc, ustar )   ! Intent(out)
 
     case ( "twp_ice" )
       l_compute_momentum_flux = .true.
       l_set_sclr_sfc_rtm_thlm = .true.
-      call twp_ice_sfclyr( time_current, gr%zt(1,2), exner(1), thlm(2), & ! Intent(in)
-                            ubar, rtm(2), p_sfc,               &        ! Intent(in)
-                            wpthlp_sfc, wprtp_sfc, ustar, T_sfc )       ! Intent(out)
+      call twp_ice_sfclyr( time_current, z_bot, exner_bot, thlm_bot, & ! Intent(in)
+                           ubar, rtm_bot, p_sfc,               &       ! Intent(in)
+                           wpthlp_sfc, wprtp_sfc, ustar, T_sfc )       ! Intent(out)
 
     case ( "wangara" )
       l_compute_momentum_flux = .true.
@@ -5373,7 +5384,7 @@ module clubb_driver
 
     ! These have been placed here to help avoid repetition in the cases
     if( l_compute_momentum_flux ) then
-      call compute_momentum_flux( um(2), vm(2), ubar, ustar, &   ! Intent(in)
+      call compute_momentum_flux( um_bot, vm_bot, ubar, ustar, & ! Intent(in)
                                   upwp_sfc, vpwp_sfc )           ! Intent(out)
     end if
 
@@ -5441,19 +5452,20 @@ module clubb_driver
     return
   end subroutine prescribe_forcings
 
-  subroutine read_surface_var_for_bc( gr, um, vm, rtm, thlm, rho_zm, exner, & ! Intent(in)
+!-------------------------------------------------------------------------------
+subroutine read_surface_var_for_bc( gr, um, vm, rtm, thlm, rho_zm, exner, & ! Intent(in)
                                       l_modify_bc_for_cnvg_test, & ! Intent(in)
-                                      z_bot, um_bot, vm_bot, rtm_bot, & ! Intent (out) 
-                                      thlm_bot, rho_bot, exner_bot ) ! Intent (out) 
+                                      z_bot, um_bot, vm_bot, rtm_bot, & ! Intent (out)
+                                      thlm_bot, rho_bot, exner_bot ) ! Intent (out)
 ! Description:
 !   Derive the physical quantities at the bottom model level for calculating
 !   surface fluxes (boundary conditions). The default option is to use the
 !   quantities at first/second model level. When l_modify_bc_for_cnvg_test =
 !   .true., the quantities at a fixed model height (25m) is obtained via
 !   vertical interpolation and used for calculating the surface fluxes. The
-!   purpose is to eleminate the space-dependence of quantities in default option 
+!   purpose is to eleminate the space-dependence of quantities in default option
 !   when model is refined vertically, which results in a space-dependence of
-!   surface fluxes. The modified option is found to be correct treatment for 
+!   surface fluxes. The modified option is found to be correct treatment for
 !   evaluating space-time convergence in CLUBB-SCM.
 !
 ! Contact: Shixuan Zhang (Shixuan.Zhang@pnnl.gov).
@@ -5492,26 +5504,26 @@ module clubb_driver
       rho_zm          ! Air density on momentum levels [kg/m^3]
 
     logical, intent(in) :: &
-      l_modify_bc_for_cnvg_test ! Flag to activate modifications on boundary condition for 
-                                ! convergence test (surface fluxes computed at fixed 25m height) 
+      l_modify_bc_for_cnvg_test ! Flag to activate modifications on boundary condition for
+                                ! convergence test (surface fluxes computed at fixed 25m height)
 
     ! the variable at a fixed model hight for the derivation of surface fluxes
     real( kind = core_rknd ), intent(out) :: &
-      z_bot,        & ! height at bottom model level [m] 
+      z_bot,        & ! height at bottom model level [m]
       um_bot,       & ! um at bottom model level (thermo. levs.) [m/s]
       vm_bot,       & ! vm at bottom model level (thermo. levs.) [m/s]
       rtm_bot,      & ! rtm at bottom model level (thermo. levs.) [kg/kg]
       thlm_bot,     & ! thlm at bottom model level (thermo. levels) [K]
-      rho_bot,      & ! rho at bottom model level (momentum levels) [kg/m^3]   
+      rho_bot,      & ! rho at bottom model level (momentum levels) [kg/m^3]
       exner_bot       ! exner at bottom model level (thermodynamic levels) [-]
 
     ! Options for finding the fixed model height
     integer, parameter :: &
-      constant_height_option   = 2 ! option 1: find the nearest level 
+      constant_height_option   = 2 ! option 1: find the nearest level
                                    ! option 2: interpolate to the constant
-                                   ! height level 
+                                   ! height level
 
-    ! Local variables 
+    ! Local variables
     real( kind = core_rknd ), dimension(gr%nz) ::  &
       z_diff,  & ! differences of the model hight and the fixed height leve
       um_zm,   &
@@ -5523,7 +5535,7 @@ module clubb_driver
     integer :: kk, km1,kp1,kp2,k00
 
     if (.not. l_modify_bc_for_cnvg_test) then
-      ! Default model setup in CLUBB-SCM 
+      ! Default model setup in CLUBB-SCM
       z_bot     = gr%zt(1,2)
       um_bot    = um(2)
       vm_bot    = vm(2)
@@ -5537,11 +5549,11 @@ module clubb_driver
       !write(unit=fstdout, fmt='(a,f10.4)')'The nearest zt-levels to z_bot = ',
       !gr%zt(1,2)
     else
-      ! Modified option which find the values of physical quantities 
+      ! Modified option which find the values of physical quantities
       ! at a fixed model height (25m)
-      z_bot  = 25.0_core_rknd !user-specified 
+      z_bot  = 25.0_core_rknd !user-specified
 
-      ! find the neareast level to the constant model height 
+      ! find the neareast level to the constant model height
       z_diff = abs(gr%zt(1,1:gr%nz) - z_bot )
       kk     = MINLOC (z_diff, DIM = 1)
 
@@ -5559,9 +5571,9 @@ module clubb_driver
         rho_bot   = rho_zm(kk-1)
         exner_bot = exner(kk)
 
-      else ! option 2 (interpolation) 
+      else ! option 2 (interpolation)
 
-        ! use the mono cubic interpolation to get the values 
+        ! use the mono cubic interpolation to get the values
         if ( kk == 2 ) then
           km1 = 1
           k00 = 1

--- a/src/clubb_tuner.F90
+++ b/src/clubb_tuner.F90
@@ -661,6 +661,8 @@ subroutine logical_flags_driver( current_date, current_time )
     l_smooth_Heaviside_tau_wpxp,  & ! Use smoothed Heaviside 'Preskin' function
                                     ! in the calculation of H_invrs_tau_wpxp_N2
                                     ! in src/CLUBB_core/mixing_length.F90
+    l_modify_bc_for_cnvg_test,    & ! Flag to activate modifications on boundary condition for
+                                      ! convergence test (surface fluxes computed at fixed 25m height)
     l_enable_relaxed_clipping,    & ! Flag to relax clipping on wpxp in
                                     ! xm_wpxp_clipping_and_stats
     l_linearize_pbl_winds,        & ! Code to linearize PBL winds
@@ -738,6 +740,7 @@ subroutine logical_flags_driver( current_date, current_time )
                                        l_use_tke_in_wp3_pr_turb_term, & ! Intent(out)
                                        l_use_tke_in_wp2_wp3_K_dfsn, & ! Intent(out)
                                        l_smooth_Heaviside_tau_wpxp, & ! Intent(out)
+                                       l_modify_bc_for_cnvg_test, & ! Intent(out)
                                        l_enable_relaxed_clipping, & ! Intent(out)
                                        l_linearize_pbl_winds, & ! Intent(out)
                                        l_mono_flux_lim_thlm, & ! Intent(out)


### PR DESCRIPTION
Hi Vince and Brian (@vlarson @bmg929): 

This pull request contains the code changes to implement an option to activate modified boundary conditions that are proved to be essential to obtain first-order convergence in CLUBB-SCM.  

In the current default CLUBB, the quantities (e.g. wind, temperature, and humidity) at the bottom model level (usually the 2nd or 1st levels) are passed to the surface flux module to calculate the surface fluxes (e.g. wprtp and wpthlp, upwp and vpwp at the surface). When we refine the model vertical grid, the bottom model level will become closer and closer to the surface, the quantities at the 1st or 2nd model level show a strong dependence on model vertical resolution, and the development of clouds is different. The code changes in this pull request attempt to add an option that allows CLUBB to calculate the surface fluxes at a fixed 25m (currently the default setup in this pull request code) model height.  The figure below show the results for RICO case with default (i.e. surface fluxes depend on resolution) and revised (surface fluxes calculated at fixed 25m model height): [rico_sfc_flux_dz_dependence.pdf](https://github.com/larson-group/clubb_release/files/10736645/rico_sfc_flux_dz_dependence.pdf). You can see that the surface fluxes and development of the cloud (during hours 1.5-2.5 ) change with the model resolution in the left column, while cloud development in simulations with different resolutions becomes more consistent in the right column when the surface fluxes are calculated at fixed 25m model height. 

To implement the new option, I introduced a new subroutine read_surface_var_for_bc() in src/ to obtain the surface quantities used to compute the surface fluxes. Associated code changes are also made in  These code modifications results in bit-for-bit results when the model is run with default setup, see figures below: 
1. **cloud fraction for RICO, BOMEX, Wangara and Dycoms2_RF02 case:** [hovmoller_cloud_frac_norevbc-crop.pdf](https://github.com/larson-group/clubb_release/files/10736795/hovmoller_cloud_frac_norevbc-crop.pdf)
2.  **wp3 for RICO, BOMEX, Wangara and Dycoms2_RF02 case:** [hovmoller_wp3_norevbc-crop.pdf](https://github.com/larson-group/clubb_release/files/10736805/hovmoller_wp3_norevbc-crop.pdf)

The flag variable "l_modify_bc_for_cnvg_test" is introduced to control the use of the newly introduced option. Here, l_modify_bc_for_cnvg_test is put in the "model_setting" section in CLUBB namelist (rather than adding it to the configurable_clubb_flags_nl).  The flag is set to .false. by default. The user can add " l_modify_bc_for_cnvg_test = .true." in the *.in file to activate the optional surface flux calculation. Here I run a set of test simulations with default configurations in CLUBB except with
- l_modify_bc_for_cnvg_test = .false.
- l_modify_bc_for_cnvg_test = .true.

respectively. The simulations were run on the standard grid with 60s time step.  

**When the  l_modify_bc_for_cnvg_test = .true., the model results are non-bit-for-bit compared with the default CLUBB, but the changes are still relatively small:** 

- Figure 1. Hovmoller diagrams for cloud fraction: [hovmoller_cloud_frac_revbc-crop.pdf](https://github.com/larson-group/clubb_release/files/10736853/hovmoller_cloud_frac_revbc-crop.pdf)
Note: the third column shows the differences between the simulations with l_modify_bc_for_cnvg_test = .false. and l_modify_bc_for_cnvg_test = .true. 
- Figure 2. Hovmoller diagrams for wp3: [hovmoller_wp3_revbc-crop.pdf](https://github.com/larson-group/clubb_release/files/10736836/hovmoller_wp3_revbc-crop.pdf)
Note: the third column shows the differences between the simulations with l_modify_bc_for_cnvg_test = .false. and l_modify_bc_for_cnvg_test = .true. 
