### PR TITLE
Update mono_flux_limiter.F90

### DIFF
--- a/src/CLUBB_core/mono_flux_limiter.F90
+++ b/src/CLUBB_core/mono_flux_limiter.F90
@@ -879,7 +879,7 @@ module mono_flux_limiter
 
           !Check to ensure the vertical integral is not zero to avoid a divide
           !by zero error
-          if (xm_vert_integral < eps) then
+          if (abs(xm_vert_integral) < eps) then
             write(fstderr,*) "Vertical integral of xm is zero;", & 
                              "mfl will remove spike at top of domain,", &
                              "but it will not conserve xm."


### PR DESCRIPTION
The line:
           if (xm_vert_integral < eps) then
is replaced with
           if (abs(xm_vert_integral) < eps) then
This is a bug fix for runs with l_predict_upwp_vpwp set to .true.  The effect of the bug is to break momentum conservation whenever barotropic flow in the PBL is easterly or northerly. The flux limiter is called for momentum only when predict_upwp is true, and it is otherwise applied only to positive definite variables (for which the condition in its present form is valid). The fix (also) removes the huge number of warnings in the log when running with predict_upwp=T.