### PR TITLE
Update outdated README instructions

### DIFF
--- a/README
+++ b/README
@@ -83,7 +83,7 @@ It can be obtained by cloning with git.
 If you have not already downloaded CLUBB, then at a bash prompt, type in the
 following command from the directory where you want the clubb folder to be
 placed, all on one line:
-user@computer ~$ git clone http://github.com/larson-group/clubb_release.git
+user@computer ~$ git clone http://github.com/larson-group/clubb_release.git clubb
 
 After entering this command, git will download the CLUBB source code into the
 directory specified as the last option in the git command; in the example

--- a/README
+++ b/README
@@ -77,28 +77,17 @@ benchmark test cases, and creating plots.
 -------------------------------------------------------
 - STEP 1: OBTAINING THE CODE FROM THE REPOSITORY
 -------------------------------------------------------
-Checking CLUBB out requires the user to be a collaborator on the clubb_release github repository.
-Sign up will require a github username.
+The CLUBB code is provided open-source on GitHub.
+It can be obtained by cloning with git.
 
-After entering the required information in the registration page, an invitation e-mail
-will be sent to the email associated with the github account entered.
+If you have not already downloaded CLUBB, then at a bash prompt, type in the
+following command from the directory where you want the clubb folder to be
+placed, all on one line:
+user@computer ~$ git clone http://github.com/larson-group/clubb_release.git
 
-Please note that each user will only need to sign up once.
-
-With the valid permissions as a collaborator, the CLUBB code can be cloned from its
-repository using git.  If you have not already downloaded CLUBB,
-then at a bash prompt, type in the following command from the directory where
-you want the clubb folder to be placed, all on one line:
-user@computer ~$ git clone http://github.com/larson-group/clubb_release.git 
-
-After entering this command, git will prompt for a username and password. 
-Use your github credentials. After the authorized credentials are entered, 
-git will download the CLUBB source code into the directory specified as the
-last option in the git command; in the example
-above, it will be downloaded to the clubb/ directory.  On some computers,
-when entering the password, the cursor may remain in the same spot
-and the screen may remain blank.  Don't be confused; hit return, and 
-your password will be entered.  
+After entering this command, git will download the CLUBB source code into the
+directory specified as the last option in the git command; in the example
+above, it will be downloaded to the clubb/ directory.
 
 -------------------------------------------------------
 - STEP 2: COMPILING THE CLUBB SOURCE CODE

--- a/README
+++ b/README
@@ -83,7 +83,7 @@ It can be obtained by cloning with git.
 If you have not already downloaded CLUBB, then at a bash prompt, type in the
 following command from the directory where you want the clubb folder to be
 placed, all on one line:
-user@computer ~$ git clone http://github.com/larson-group/clubb_release.git clubb
+user@computer ~$ git clone https://github.com/larson-group/clubb_release.git clubb
 
 After entering this command, git will download the CLUBB source code into the
 directory specified as the last option in the git command; in the example

--- a/src/CLUBB_core/version_clubb_core.txt
+++ b/src/CLUBB_core/version_clubb_core.txt
@@ -1,0 +1,219 @@
+commit 46cac2787c3802be0418762948ad6d1231dde182
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Sat May 24 07:04:28 2025 -0500
+
+    Clean out clubb_G_unit_reverse_dir_grid_test folder before running Jenkins test
+
+commit dd5f915658016e9a8b64128024eebaf4c7d24318
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Fri May 23 13:13:53 2025 -0500
+
+    Finished my notes, documentation, and instructions for the generalized
+    grid test.
+
+commit 003b6cf728915e52cba23dc54bd3ae5ea9ee6364
+Author: st3113n <0-freundlich-adenin@icloud.com>
+Date:   Thu May 22 20:25:09 2025 -0500
+
+    add fix for grid generalization
+
+commit f1798e4237187cb3f36a25c73293c27e6453b0eb
+Author: st3113n <0-freundlich-adenin@icloud.com>
+Date:   Thu May 22 20:01:59 2025 -0500
+
+    rename grid_adaptation and remapping modules
+
+commit 01cd6d52d06689c704a7dc1b8239f1a6a82db237
+Author: st3113n <110198346+st3113n@users.noreply.github.com>
+Date:   Thu May 22 18:08:16 2025 -0500
+
+    fix precision error of reals
+
+commit ab83782970ee2389c03e0b387abc35b6452418bc
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Thu May 22 11:24:58 2025 -0500
+
+    I start adding some notes on grid generalization.
+
+commit 25d5bed515ab3d6e11e43419ef1fc3a71777e545
+Author: st3113n <110198346+st3113n@users.noreply.github.com>
+Date:   Wed May 21 17:32:02 2025 -0500
+
+    Merge grid adaptation implementation (#1249)
+    
+    * add tunable parameter interp_from_dycore_grid_method
+    
+    * add dycore interpolation to atex case with conservative remapping by ullrich
+    
+    * remove new gpu commands
+    
+    * add acc annotation for gpu
+    
+    * remove acc annotation again
+    
+    * add acc annotation for parallel loop
+    
+    * add acc annotations for parallel loop execution
+    
+    * change remapping subroutine to take number of levels and levels as input instead of whole grid object
+    
+    * add more general functions to interpolate
+    
+    * add and refactor functions for remapping values given on zm levels
+    
+    * fix compiler errors and refactoring to stay under 100 chars per line
+    
+    * remove TODOs and used new interpolating function in interpolate_forcings
+    
+    * add functions for adaptive grid generation and grid density function normalization
+    
+    * add conservative ullrich remapping to cases with forcing time dependent inputs
+    
+    * add grid adaptation and flag
+    
+    * clean up and add warning for case when remapping from dycore flag cannot be used
+    
+    * some refactoring
+    
+    * add logical flag for dycore and renamed flags for dycore and grid adaptation
+    
+    * remove ifdefs
+    
+    * refactoring
+    
+    * add units
+    
+    * changed Lscale to inverse
+    
+    * add write to file for grid adaptation (still WIP)
+    
+    * clean up
+    
+    * change parameter for grid adaptation and add file and plot script for grid adaptation
+    
+    * add script for animation
+    
+    * add e3sm dycore grid
+    
+    * refactoring for efficiency
+    
+    * small fix for grid adapt plot script
+    
+    * add new grid adaptation method with prescribed minimum density profile
+    
+    * fix call to setup_grid
+    
+    * add gabls2 case
+    
+    * add refinement criterion and adaptation trigger
+    
+    * small fix and add minimum grid density profile to animation
+    
+    * add grid density to pyplots
+    
+    * add general refinement criteria for astex and gabls2 case (and arm)
+    
+    * update create_evenly_grid script
+    
+    * unfinished save
+    
+    * WIP: save progress
+    
+    * save working configuration
+    
+    * save working config without Lscale
+    
+    * save working config wo the use of Lscale
+    
+    * change call to map1_ppm to use correct iv parameter and order 4
+    
+    * save code for results in thesis
+    
+    * add code for results
+    
+    * refactor remapping module for grid adaptation
+    
+    * add list of functions/subroutines to remapping module
+    
+    * adjust use statements
+    
+    * add model files for arm, astex and gabls2
+    
+    * refactor grid_adaptation module
+    
+    * refactor and adjust tim stopping in clubb_driver
+    
+    * clean up
+    
+    * clean up
+    
+    * add grids
+    
+    * add scripts
+    
+    * add changes made to pyplotgen to generate plots for paper
+    
+    * add configurable model flags file that was used to obtain results
+    
+    * clean up and save tunable parameters file
+    
+    * fix error
+    
+    * fix error
+    
+    * add grid adapt output for debug level 2
+    
+    * change dycore grid
+    
+    * add plot generation script for paper plots
+    
+    * add small changes
+    
+    * add normalization explaination plot to paper plots script
+    
+    * fix plot
+    
+    * clean up for stats output
+    
+    * add comment
+    
+    * fix use of clubb_at_least_debug_api
+    
+    * small deallocation fix
+    
+    * fix merge problems
+    
+    * revert changes made to test grid adaptation
+    
+    * revert tunable_parameters for Lscale
+    
+    * revert changes made to create plots for grid adaptation
+    
+    * add new line
+    
+    * add new line
+    
+    * revert changes
+    
+    * revert changes made to generate grid adaptation plots
+
+commit df1dbd76ba2ecb03a34137394fbb108eba6a3406
+Merge: b5929aa67 ec0644cf8
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Tue May 20 00:55:19 2025 -0500
+
+    Merge branch 'master' of github.com:larson-group/clubb
+
+commit b5929aa672244c4324f925e9c05fb2eb39baa1be
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Tue May 20 00:54:46 2025 -0500
+
+    zm and zt were mixed up in the error prints argument list.
+
+commit ec0644cf80b501f02e9f43a32d39c9aeb784d669
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Mon May 19 23:11:42 2025 -0500
+
+    For the long-duration clubb_generalized_vertical_grid_test, I am
+    shortening the duration of the MC3E runs to half their normal number
+    of timesteps in order to cut down on the time it takes to do the run.

--- a/src/SILHS/version_silhs.txt
+++ b/src/SILHS/version_silhs.txt
@@ -1,0 +1,219 @@
+commit 46cac2787c3802be0418762948ad6d1231dde182
+Author: Vincent Larson <vlarson@users.noreply.github.com>
+Date:   Sat May 24 07:04:28 2025 -0500
+
+    Clean out clubb_G_unit_reverse_dir_grid_test folder before running Jenkins test
+
+commit dd5f915658016e9a8b64128024eebaf4c7d24318
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Fri May 23 13:13:53 2025 -0500
+
+    Finished my notes, documentation, and instructions for the generalized
+    grid test.
+
+commit 003b6cf728915e52cba23dc54bd3ae5ea9ee6364
+Author: st3113n <0-freundlich-adenin@icloud.com>
+Date:   Thu May 22 20:25:09 2025 -0500
+
+    add fix for grid generalization
+
+commit f1798e4237187cb3f36a25c73293c27e6453b0eb
+Author: st3113n <0-freundlich-adenin@icloud.com>
+Date:   Thu May 22 20:01:59 2025 -0500
+
+    rename grid_adaptation and remapping modules
+
+commit 01cd6d52d06689c704a7dc1b8239f1a6a82db237
+Author: st3113n <110198346+st3113n@users.noreply.github.com>
+Date:   Thu May 22 18:08:16 2025 -0500
+
+    fix precision error of reals
+
+commit ab83782970ee2389c03e0b387abc35b6452418bc
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Thu May 22 11:24:58 2025 -0500
+
+    I start adding some notes on grid generalization.
+
+commit 25d5bed515ab3d6e11e43419ef1fc3a71777e545
+Author: st3113n <110198346+st3113n@users.noreply.github.com>
+Date:   Wed May 21 17:32:02 2025 -0500
+
+    Merge grid adaptation implementation (#1249)
+    
+    * add tunable parameter interp_from_dycore_grid_method
+    
+    * add dycore interpolation to atex case with conservative remapping by ullrich
+    
+    * remove new gpu commands
+    
+    * add acc annotation for gpu
+    
+    * remove acc annotation again
+    
+    * add acc annotation for parallel loop
+    
+    * add acc annotations for parallel loop execution
+    
+    * change remapping subroutine to take number of levels and levels as input instead of whole grid object
+    
+    * add more general functions to interpolate
+    
+    * add and refactor functions for remapping values given on zm levels
+    
+    * fix compiler errors and refactoring to stay under 100 chars per line
+    
+    * remove TODOs and used new interpolating function in interpolate_forcings
+    
+    * add functions for adaptive grid generation and grid density function normalization
+    
+    * add conservative ullrich remapping to cases with forcing time dependent inputs
+    
+    * add grid adaptation and flag
+    
+    * clean up and add warning for case when remapping from dycore flag cannot be used
+    
+    * some refactoring
+    
+    * add logical flag for dycore and renamed flags for dycore and grid adaptation
+    
+    * remove ifdefs
+    
+    * refactoring
+    
+    * add units
+    
+    * changed Lscale to inverse
+    
+    * add write to file for grid adaptation (still WIP)
+    
+    * clean up
+    
+    * change parameter for grid adaptation and add file and plot script for grid adaptation
+    
+    * add script for animation
+    
+    * add e3sm dycore grid
+    
+    * refactoring for efficiency
+    
+    * small fix for grid adapt plot script
+    
+    * add new grid adaptation method with prescribed minimum density profile
+    
+    * fix call to setup_grid
+    
+    * add gabls2 case
+    
+    * add refinement criterion and adaptation trigger
+    
+    * small fix and add minimum grid density profile to animation
+    
+    * add grid density to pyplots
+    
+    * add general refinement criteria for astex and gabls2 case (and arm)
+    
+    * update create_evenly_grid script
+    
+    * unfinished save
+    
+    * WIP: save progress
+    
+    * save working configuration
+    
+    * save working config without Lscale
+    
+    * save working config wo the use of Lscale
+    
+    * change call to map1_ppm to use correct iv parameter and order 4
+    
+    * save code for results in thesis
+    
+    * add code for results
+    
+    * refactor remapping module for grid adaptation
+    
+    * add list of functions/subroutines to remapping module
+    
+    * adjust use statements
+    
+    * add model files for arm, astex and gabls2
+    
+    * refactor grid_adaptation module
+    
+    * refactor and adjust tim stopping in clubb_driver
+    
+    * clean up
+    
+    * clean up
+    
+    * add grids
+    
+    * add scripts
+    
+    * add changes made to pyplotgen to generate plots for paper
+    
+    * add configurable model flags file that was used to obtain results
+    
+    * clean up and save tunable parameters file
+    
+    * fix error
+    
+    * fix error
+    
+    * add grid adapt output for debug level 2
+    
+    * change dycore grid
+    
+    * add plot generation script for paper plots
+    
+    * add small changes
+    
+    * add normalization explaination plot to paper plots script
+    
+    * fix plot
+    
+    * clean up for stats output
+    
+    * add comment
+    
+    * fix use of clubb_at_least_debug_api
+    
+    * small deallocation fix
+    
+    * fix merge problems
+    
+    * revert changes made to test grid adaptation
+    
+    * revert tunable_parameters for Lscale
+    
+    * revert changes made to create plots for grid adaptation
+    
+    * add new line
+    
+    * add new line
+    
+    * revert changes
+    
+    * revert changes made to generate grid adaptation plots
+
+commit df1dbd76ba2ecb03a34137394fbb108eba6a3406
+Merge: b5929aa67 ec0644cf8
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Tue May 20 00:55:19 2025 -0500
+
+    Merge branch 'master' of github.com:larson-group/clubb
+
+commit b5929aa672244c4324f925e9c05fb2eb39baa1be
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Tue May 20 00:54:46 2025 -0500
+
+    zm and zt were mixed up in the error prints argument list.
+
+commit ec0644cf80b501f02e9f43a32d39c9aeb784d669
+Author: bmg929 <bmg2@uwm.edu>
+Date:   Mon May 19 23:11:42 2025 -0500
+
+    For the long-duration clubb_generalized_vertical_grid_test, I am
+    shortening the duration of the MC3E runs to half their normal number
+    of timesteps in order to cut down on the time it takes to do the run.


### PR DESCRIPTION
Hi There,

I am looking at CLUBB and am in the process of setting things up.

Whilst following the, generally very comprehensive, README I found that there were some outdated/incorrect instructions around obtaining the code.

Looking through git blame it seems these lines have not been updated in 7 or 9 years.
I presume at this time CLUBB was closed source, requiring login access to a private GitHub repository, but has since been released open source.

I have made changes to reflect this in the README text in this PR.

I also corrected a small typo in the clone command to reflect the text that describes cloning to a repository named differently to the GitHub repo.